### PR TITLE
feat: add Microduck robot and integrate it into humanoid walk task

### DIFF
--- a/configs/task/microduck-walk-flat/motrix.fastsac.yaml
+++ b/configs/task/microduck-walk-flat/motrix.fastsac.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+# Task microduck-walk-flat: motrix.fastsac shared training recipe.
+defaults:
+  - /algo_base@algo: motrix.fastsac
+  - _self_
+task:
+  env: microduck-walk-flat
+  rllib: motrix
+  algo: fastsac
+num_envs: 2048
+play_num_envs: 16
+seed: 1
+checkpoint:
+  interval: 1000
+algo:
+  agent:
+    alpha_init: 0.01
+    target_entropy_ratio: -0.1
+    num_updates: 4

--- a/configs/task/microduck-walk-rough/motrix.fastsac.yaml
+++ b/configs/task/microduck-walk-rough/motrix.fastsac.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+# Task microduck-walk-rough: motrix.fastsac shared training recipe.
+defaults:
+  - /algo_base@algo: motrix.fastsac
+  - _self_
+task:
+  env: microduck-walk-rough
+  rllib: motrix
+  algo: fastsac
+num_envs: 2048
+play_num_envs: 16
+seed: 1
+checkpoint:
+  interval: 1000
+algo:
+  agent:
+    alpha_init: 0.01
+    target_entropy_ratio: -0.1
+    num_updates: 4

--- a/docs/scripts/generate_robot_docs.py
+++ b/docs/scripts/generate_robot_docs.py
@@ -38,6 +38,7 @@ _ROBOT_METADATA = {
     "go1": {"kind": "quadruped", "lookat": (0.0, 0.0, 0.3), "distance": 1.4},
     "go2": {"kind": "quadruped", "lookat": (0.0, 0.0, 0.3), "distance": 1.4},
     "k1": {"kind": "humanoid", "lookat": (0.0, 0.0, 0.8), "distance": 2.1},
+    "microduck": {"kind": "humanoid", "lookat": (0.0, 0.0, 0.15), "distance": 0.8},
 }
 
 _DOC_CONFIGS = {

--- a/docs/source/_static/images/poster/microduck-walk-flat.jpg
+++ b/docs/source/_static/images/poster/microduck-walk-flat.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44f5cf7b759cb8ef8151818a882b780181a611e3a231bea001467adb65371ed9
+size 31796

--- a/docs/source/_static/images/poster/microduck-walk-rough.jpg
+++ b/docs/source/_static/images/poster/microduck-walk-rough.jpg
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4e7600d4467cacd92e1e32ab40e9334c38a83f0156e0e5032fcd41cfd59a84de
+size 41509

--- a/docs/source/_static/images/robots/microduck.png
+++ b/docs/source/_static/images/robots/microduck.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8d0d8814ec90cf39cbbe562231aee4bd0dfcb8426742b7724946ea7ce52ae471
+size 585301

--- a/docs/source/en/user_guide/envs/index.md
+++ b/docs/source/en/user_guide/envs/index.md
@@ -66,6 +66,8 @@ uv run scripts/view.py env=<env-id>
 | <img src="../../_static/images/poster/k1-walk-flat.jpg" alt="k1-walk-flat" width="240"> | `k1-walk-flat` | Track walking commands with Booster K1 on flat ground. | `motrix.fastsac` |
 | <img src="../../_static/images/poster/k1-walk-rough.jpg" alt="k1-walk-rough" width="240"> | `k1-walk-rough` | Track walking commands with Booster K1 over uneven terrain. | `motrix.fastsac` |
 | <img src="../../_static/images/poster/k1-wbt-freekick.jpg" alt="k1-wbt-freekick" width="240"> | `k1-wbt-freekick` | Track a free-kick reference motion with Booster K1. | `motrix.fastsac` |
+| <img src="../../_static/images/poster/microduck-walk-flat.jpg" alt="microduck-walk-flat" width="240"> | `microduck-walk-flat` | Track walking commands with Microduck on flat ground. | `motrix.fastsac` |
+| <img src="../../_static/images/poster/microduck-walk-rough.jpg" alt="microduck-walk-rough" width="240"> | `microduck-walk-rough` | Track walking commands with Microduck over uneven terrain. | `motrix.fastsac` |
 | <img src="../../_static/images/poster/peg-insert.jpg" alt="peg-insert" width="240"> | `peg-insert` | Control RM65 to grasp, align, and insert a peg into a socket. | `motrix.fastsac`, `skrl.ppo` |
 | <img src="../../_static/images/poster/pendulum.jpg" alt="pendulum" width="240"> | `pendulum` | Apply joint torque to swing up and balance a pendulum. | `rslrl.ppo`, `skrl.ppo` |
 | <img src="../../_static/images/poster/point_mass.jpg" alt="point_mass" width="240"> | `point_mass` | Move a two-dimensional point mass to a random target. | `skrl.ppo` |

--- a/docs/source/en/user_guide/robots.md
+++ b/docs/source/en/user_guide/robots.md
@@ -8,15 +8,15 @@ be composed into different scenes and tasks. The table below is generated direct
 <!-- ROBOT_TABLE_START -->
 
 <!-- This table is generated; do not edit this block manually. -->
-
-| Screenshot                                                                   | Registry name | Configuration class | Type      | Model format | DoF |
-| ---------------------------------------------------------------------------- | ------------- | ------------------- | --------- | ------------ | --- |
-| <img src="../_static/images/robots/anymal_c.png" alt="anymal_c" width="180"> | `anymal_c`    | `AnymalC`           | Quadruped | MJCF         | 12  |
-| <img src="../_static/images/robots/dex-evt.png" alt="dex-evt" width="180">   | `dex-evt`     | `DexEvt`            | Humanoid  | URDF         | 23  |
-| <img src="../_static/images/robots/g1-29dof.png" alt="g1-29dof" width="180"> | `g1-29dof`    | `UnitreeG129Dof`    | Humanoid  | MJCF         | 29  |
-| <img src="../_static/images/robots/go1.png" alt="go1" width="180">           | `go1`         | `UnitreeGo1Robot`   | Quadruped | MJCF         | 12  |
-| <img src="../_static/images/robots/go2.png" alt="go2" width="180">           | `go2`         | `UnitreeGo2Robot`   | Quadruped | MJCF         | 12  |
-| <img src="../_static/images/robots/k1.png" alt="k1" width="180">             | `k1`          | `BoosterK1`         | Humanoid  | MJCF         | 22  |
+| Screenshot | Registry name | Configuration class | Type | Model format | DoF |
+| --- | --- | --- | --- | --- | --- |
+| <img src="../_static/images/robots/anymal_c.png" alt="anymal_c" width="180"> | `anymal_c` | `AnymalC` | Quadruped | MJCF | 12 |
+| <img src="../_static/images/robots/dex-evt.png" alt="dex-evt" width="180"> | `dex-evt` | `DexEvt` | Humanoid | URDF | 23 |
+| <img src="../_static/images/robots/g1-29dof.png" alt="g1-29dof" width="180"> | `g1-29dof` | `UnitreeG129Dof` | Humanoid | MJCF | 29 |
+| <img src="../_static/images/robots/go1.png" alt="go1" width="180"> | `go1` | `UnitreeGo1Robot` | Quadruped | MJCF | 12 |
+| <img src="../_static/images/robots/go2.png" alt="go2" width="180"> | `go2` | `UnitreeGo2Robot` | Quadruped | MJCF | 12 |
+| <img src="../_static/images/robots/k1.png" alt="k1" width="180"> | `k1` | `BoosterK1` | Humanoid | MJCF | 22 |
+| <img src="../_static/images/robots/microduck.png" alt="microduck" width="180"> | `microduck` | `Microduck` | Humanoid | MJCF | 14 |
 
 <!-- ROBOT_TABLE_END -->
 

--- a/docs/source/zh_CN/user_guide/envs/index.md
+++ b/docs/source/zh_CN/user_guide/envs/index.md
@@ -66,6 +66,8 @@ uv run scripts/view.py env=<env-id>
 | <img src="../../_static/images/poster/k1-walk-flat.jpg" alt="k1-walk-flat" width="240"> | `k1-walk-flat` | 控制 Booster K1 在平地上跟踪行走指令。 | `motrix.fastsac` |
 | <img src="../../_static/images/poster/k1-walk-rough.jpg" alt="k1-walk-rough" width="240"> | `k1-walk-rough` | 控制 Booster K1 在起伏地形上跟踪行走指令。 | `motrix.fastsac` |
 | <img src="../../_static/images/poster/k1-wbt-freekick.jpg" alt="k1-wbt-freekick" width="240"> | `k1-wbt-freekick` | 让 Booster K1 跟踪任意球射门参考动作。 | `motrix.fastsac` |
+| <img src="../../_static/images/poster/microduck-walk-flat.jpg" alt="microduck-walk-flat" width="240"> | `microduck-walk-flat` | 控制 Microduck 小型双足机器人在平地上跟踪行走指令。 | `motrix.fastsac` |
+| <img src="../../_static/images/poster/microduck-walk-rough.jpg" alt="microduck-walk-rough" width="240"> | `microduck-walk-rough` | 控制 Microduck 小型双足机器人在起伏地形上跟踪行走指令。 | `motrix.fastsac` |
 | <img src="../../_static/images/poster/peg-insert.jpg" alt="peg-insert" width="240"> | `peg-insert` | 控制 RM65 抓取插销、对准插座并完成插入。 | `motrix.fastsac`, `skrl.ppo` |
 | <img src="../../_static/images/poster/pendulum.jpg" alt="pendulum" width="240"> | `pendulum` | 施加关节力矩使单摆摆起并保持直立。 | `rslrl.ppo`, `skrl.ppo` |
 | <img src="../../_static/images/poster/point_mass.jpg" alt="point_mass" width="240"> | `point_mass` | 控制二维质点移动到随机目标位置。 | `skrl.ppo` |

--- a/docs/source/zh_CN/user_guide/robots.md
+++ b/docs/source/zh_CN/user_guide/robots.md
@@ -8,15 +8,15 @@ scene 和 task 中。下表直接根据 registry 和 robot 配置生成。
 <!-- ROBOT_TABLE_START -->
 
 <!-- This table is generated; do not edit this block manually. -->
-
-| 截图                                                                         | Registry 名称 | 配置类            | 类型       | 模型格式 | 自由度 |
-| ---------------------------------------------------------------------------- | ------------- | ----------------- | ---------- | -------- | ------ |
-| <img src="../_static/images/robots/anymal_c.png" alt="anymal_c" width="180"> | `anymal_c`    | `AnymalC`         | 四足机器人 | MJCF     | 12     |
-| <img src="../_static/images/robots/dex-evt.png" alt="dex-evt" width="180">   | `dex-evt`     | `DexEvt`          | 人形机器人 | URDF     | 23     |
-| <img src="../_static/images/robots/g1-29dof.png" alt="g1-29dof" width="180"> | `g1-29dof`    | `UnitreeG129Dof`  | 人形机器人 | MJCF     | 29     |
-| <img src="../_static/images/robots/go1.png" alt="go1" width="180">           | `go1`         | `UnitreeGo1Robot` | 四足机器人 | MJCF     | 12     |
-| <img src="../_static/images/robots/go2.png" alt="go2" width="180">           | `go2`         | `UnitreeGo2Robot` | 四足机器人 | MJCF     | 12     |
-| <img src="../_static/images/robots/k1.png" alt="k1" width="180">             | `k1`          | `BoosterK1`       | 人形机器人 | MJCF     | 22     |
+| 截图 | Registry 名称 | 配置类 | 类型 | 模型格式 | 自由度 |
+| --- | --- | --- | --- | --- | --- |
+| <img src="../_static/images/robots/anymal_c.png" alt="anymal_c" width="180"> | `anymal_c` | `AnymalC` | 四足机器人 | MJCF | 12 |
+| <img src="../_static/images/robots/dex-evt.png" alt="dex-evt" width="180"> | `dex-evt` | `DexEvt` | 人形机器人 | URDF | 23 |
+| <img src="../_static/images/robots/g1-29dof.png" alt="g1-29dof" width="180"> | `g1-29dof` | `UnitreeG129Dof` | 人形机器人 | MJCF | 29 |
+| <img src="../_static/images/robots/go1.png" alt="go1" width="180"> | `go1` | `UnitreeGo1Robot` | 四足机器人 | MJCF | 12 |
+| <img src="../_static/images/robots/go2.png" alt="go2" width="180"> | `go2` | `UnitreeGo2Robot` | 四足机器人 | MJCF | 12 |
+| <img src="../_static/images/robots/k1.png" alt="k1" width="180"> | `k1` | `BoosterK1` | 人形机器人 | MJCF | 22 |
+| <img src="../_static/images/robots/microduck.png" alt="microduck" width="180"> | `microduck` | `Microduck` | 人形机器人 | MJCF | 14 |
 
 <!-- ROBOT_TABLE_END -->
 

--- a/motrix_envs/src/motrix_envs/locomotion/humanoid/__init__.py
+++ b/motrix_envs/src/motrix_envs/locomotion/humanoid/__init__.py
@@ -3,4 +3,4 @@
 
 """Robot-agnostic humanoid locomotion environments and configuration schemas."""
 
-from . import dex_evt, g1, k1, walk_np  # noqa: F401 register envs and expose base task
+from . import dex_evt, g1, k1, microduck, walk_np  # noqa: F401 register envs and expose base task

--- a/motrix_envs/src/motrix_envs/locomotion/humanoid/microduck.py
+++ b/motrix_envs/src/motrix_envs/locomotion/humanoid/microduck.py
@@ -1,0 +1,123 @@
+# Copyright Motphys Technology Co., Ltd. 2025, 2026
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pollen Robotics Microduck humanoid velocity-tracking presets and registration."""
+
+from dataclasses import replace
+
+from motrix_env_core import registry
+from motrix_env_core.base import SimCfg
+from motrix_env_core.config.scene import HFieldTerrainCfg, SystemCameraCfg
+from motrix_envs.config.scene import StandardSceneObjsCfg
+from motrix_envs.locomotion.humanoid import cfg as humanoid_cfg
+from motrix_envs.locomotion.humanoid.walk_np import HumanoidVelocityTrackingEnv
+from motrix_envs.robot import Microduck
+
+
+def _make_microduck_robot() -> Microduck:
+    return Microduck()
+
+
+# Pinned Microduck termination collision inventory, owned by the Microduck walk task.
+_MICRODUCK_TERMINATION_GEOMS = ("trunk_collision",)
+
+
+@registry.envcfg("microduck-walk-flat")
+def make_microduck_walk_flat_cfg() -> humanoid_cfg.HumanoidVelocityTrackingEnvCfg:
+    """Track walking commands with Microduck on flat ground.
+
+    zh_CN: 控制 Microduck 小型双足机器人在平地上跟踪行走指令。
+    """
+
+    return humanoid_cfg.HumanoidVelocityTrackingEnvCfg(
+        scene=humanoid_cfg.HumanoidWalkSceneCfg(
+            # Microduck is a ~25 cm robot; frame the lead env much closer than
+            # the full-size humanoid default camera (grid center at z=0.75).
+            system_camera=SystemCameraCfg(
+                lookat=(0.0, 0.0, 0.12),
+                distance=0.35,
+                elevation=-20.0,
+                azimuth=180.0,
+            ),
+            objs=StandardSceneObjsCfg(robot=_make_microduck_robot()),
+        ),
+        control_config=humanoid_cfg.ControlCfg(action_scale=0.5),
+        commands=humanoid_cfg.CommandsCfg(
+            vel_limit=[
+                [-1.0, -1.0, -1.0],
+                [1.0, 1.0, 1.0],
+            ],
+        ),
+        gait=humanoid_cfg.GaitCfg(
+            period=0.5,
+            swing_height=0.04,
+            feet_phase_sigma=0.002,
+        ),
+        reward_config=humanoid_cfg.RewardCfg(
+            scales=humanoid_cfg.RewardScales(
+                tracking_lin_vel=10.0,
+                tracking_ang_vel=3.0,
+                penalty_action_rate=-0.5,
+                feet_phase=8.0,
+            ),
+            tracking_sigma=0.15,
+            close_feet_threshold=0.05,
+            pose_weights={
+                "left_hip_yaw": 5.0,
+                "left_hip_roll": 1.0,
+                "left_hip_pitch": 0.01,
+                "left_knee": 0.01,
+                "left_ankle": 5.0,
+                "neck_pitch": 50.0,
+                "head_pitch": 50.0,
+                "head_yaw": 50.0,
+                "head_roll": 50.0,
+                "right_hip_yaw": 5.0,
+                "right_hip_roll": 1.0,
+                "right_hip_pitch": 0.01,
+                "right_knee": 0.01,
+                "right_ankle": 5.0,
+            },
+        ),
+        asset=humanoid_cfg.AssetCfg(
+            foot_height_site_names=("left_foot", "right_foot"),
+            ground_geom_name="floor",
+            terminate_contact_geom_names=_MICRODUCK_TERMINATION_GEOMS,
+        ),
+        sim=SimCfg(dt=0.005, solver_iterations=6, solver_tolerance=1e-4),
+        spawn_xy_range=0.0,
+    )
+
+
+@registry.envcfg("microduck-walk-rough")
+def make_microduck_walk_rough_cfg() -> humanoid_cfg.HumanoidVelocityTrackingEnvCfg:
+    """Track walking commands with Microduck over uneven terrain.
+
+    zh_CN: 控制 Microduck 小型双足机器人在起伏地形上跟踪行走指令。
+    """
+
+    return replace(
+        make_microduck_walk_flat_cfg(),
+        scene=humanoid_cfg.HumanoidWalkSceneCfg(
+            assets=humanoid_cfg.TerrainSceneAssetsCfg(),
+            system_camera=SystemCameraCfg(
+                lookat=(0.0, 0.0, 0.12),
+                distance=0.35,
+                elevation=-20.0,
+                azimuth=180.0,
+            ),
+            objs=StandardSceneObjsCfg(
+                floor=HFieldTerrainCfg(
+                    hfield="terrain",
+                    material="mat_ground",
+                ),
+                robot=_make_microduck_robot(),
+            ),
+        ),
+        spawn_xy_range=4.0,
+        render_spacing=0.0,
+    )
+
+
+registry.env("microduck-walk-flat")(HumanoidVelocityTrackingEnv)
+registry.env("microduck-walk-rough")(HumanoidVelocityTrackingEnv)

--- a/motrix_envs/src/motrix_envs/locomotion/humanoid/walk_np.py
+++ b/motrix_envs/src/motrix_envs/locomotion/humanoid/walk_np.py
@@ -171,6 +171,11 @@ class HumanoidVelocityTrackingEnv(DirectEnv[HumanoidVelocityTrackingEnvCfg]):
         self._phase_dt = 2.0 * np.pi * self._gait_freq * cfg.ctrl_dt
         self._termination_geoms = self._resolve_termination_geoms()
         self._num_termination_pairs = len(self._termination_geoms)
+        # Foot-link gravity direction at the default pose, captured on first
+        # reset. Foot orientation penalties are measured against this
+        # reference so robots whose ankle-link frames are not world-aligned
+        # (e.g. onshape-to-robot exports) are scored correctly.
+        self._default_foot_gravity: np.ndarray | None = None
 
         cur = cfg.curriculum
         self._penalty_terms = set(cur.penalty_terms)
@@ -392,6 +397,9 @@ class HumanoidVelocityTrackingEnv(DirectEnv[HumanoidVelocityTrackingEnvCfg]):
         self._reset_joint_velocity[env_ids] = 0.0
         self._reset_program.execute(env_ids)
         self.sim_data.execute(row_ids)
+        if self._default_foot_gravity is None:
+            foot_quat = self.sim_data["foot_quat"][row_ids[0]]
+            self._default_foot_gravity = quaternion.rotate_inverse(foot_quat, self.gravity_vec)
 
         info = {
             "current_actions": np.zeros((num_reset, self._num_action), dtype=np.float32),
@@ -462,8 +470,12 @@ class HumanoidVelocityTrackingEnv(DirectEnv[HumanoidVelocityTrackingEnvCfg]):
         return (distance < threshold).astype(np.float32)
 
     def _r_feet_ori(self, q: StateQuantities) -> np.ndarray:
+        # Magnitude of the cross product between the current foot-frame gravity
+        # and its default-pose reference. With a world-aligned default
+        # (gravity = (0, 0, -1)) this reduces exactly to sqrt(gx^2 + gy^2).
         total = np.zeros((q.foot_quat.shape[0],), dtype=np.float32)
         for foot_index in range(2):
             foot_gravity = quaternion.rotate_inverse(q.foot_quat[:, foot_index], self.gravity_vec)
-            total = total + np.sqrt(np.sum(np.square(foot_gravity[:, :2]), axis=1))
+            reference = self._default_foot_gravity[foot_index]
+            total = total + np.linalg.norm(np.cross(foot_gravity, reference), axis=1)
         return total

--- a/motrix_envs/src/motrix_envs/robot/__init__.py
+++ b/motrix_envs/src/motrix_envs/robot/__init__.py
@@ -6,6 +6,7 @@ from motrix_envs.robot.anymal import AnymalC
 from motrix_envs.robot.booster import BoosterK1
 from motrix_envs.robot.dex_evt import DexEvt
 from motrix_envs.robot.humanoid import HumanoidRobotCfg
+from motrix_envs.robot.microduck import Microduck
 from motrix_envs.robot.quadruped import QuadrupedLegCfg, QuadrupedLegsCfg, QuadrupedRobotCfg
 from motrix_envs.robot.unitree import (
     UnitreeG129Dof,
@@ -19,12 +20,14 @@ registry.robotcfg("g1-29dof")(UnitreeG129Dof)
 registry.robotcfg("go1")(UnitreeGo1Robot)
 registry.robotcfg("go2")(UnitreeGo2Robot)
 registry.robotcfg("k1")(BoosterK1)
+registry.robotcfg("microduck")(Microduck)
 
 __all__ = [
     "AnymalC",
     "BoosterK1",
     "DexEvt",
     "HumanoidRobotCfg",
+    "Microduck",
     "QuadrupedLegCfg",
     "QuadrupedLegsCfg",
     "QuadrupedRobotCfg",

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/README.md
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/README.md
@@ -1,0 +1,14 @@
+# Microduck robot model
+
+Ported from https://github.com/pollen-robotics/microduck_rl
+(`src/mjlab_microduck/robot/microduck/robot_walk.xml`, renamed to
+`microduck.xml`). Relative to upstream, a named termination capsule
+`trunk_collision` was added on `trunk_base` for the humanoid walk task's
+fall-termination contact query; everything else is unmodified.
+
+- Upstream code and MJCF: Apache License 2.0
+- 3D mesh files (`assets/*.stl`): Creative Commons BY-SA-NC
+  (non-commercial), per the upstream README
+
+The Microduck is a ~800 g, ~25 cm bipedal robot by Pollen Robotics with 14
+actuated joints (5 per leg, 4 neck/head).

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/ankle_left.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/ankle_left.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2ec1bd89205b407efebaa9a8898ad9fea741389d87b80ecc5c96b21d1668119e
+size 248984

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/ankle_right.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/ankle_right.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f83f388ae00787415e76b8ecaab769f08f25b8c4e90c1937ff0fc4d68d81722e
+size 248884

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/banana_pcb_locker.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/banana_pcb_locker.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:42ddde9d01bf5d91f88b99847017f14d97d2537ee27383c6d41dd8bf30a51134
+size 69484

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/bearing_roll.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/bearing_roll.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b5603a64b2d965ad75ea847767b5798130852e12a658fde7b5068fc457e2adcc
+size 121084

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/bottom_head_shell.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/bottom_head_shell.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1820f7cf96646b0fc0c431f07da87b91b13111bfa9857ab1bf2b1fc3388f8da2
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/elec_rpi_robot_hat_pcb.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/elec_rpi_robot_hat_pcb.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1a61582759d82b5b4df9b7d11099bf1bb3944fc77e6b74d3237adf24dd5d03d7
+size 942884

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/face_part.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/face_part.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0e89a173e7bdc8038c4d413f458140d8f42f1a2f098f67a887c2388eff31718
+size 570684

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/foot_left.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/foot_left.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a1f5d43456d0f522bd60870153795f1e8112c1adf9b8b4373b59608d9545c044
+size 996184

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/foot_right.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/foot_right.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:54f97fa1f0e0e611d31329df9f3c3b17ffcca2d695c579d1d32cbe99e8a6c7ef
+size 997684

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/hip_l.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/hip_l.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e175896932d76dc7648cf939aa39cb7b1d188b783d91745adb9a4cec65e9052c
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/jaw.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/jaw.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45cdbd319a4583095d8daa0db07dee726522a743d59acb82d27d82ded500a1cf
+size 495984

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/jaw_soft.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/jaw_soft.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2d2ade4e86df4b37ce313bb9b96023109dd04bab39dba08b154e76d332fbce2e
+size 336384

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/left_shell.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/left_shell.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2abde8e2b79c9b011cdb11957c67ab4287b45d7301affd4235ab81141118e331
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/leg.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/leg.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a91cc1ae31ecd9e0c1ba93f3bb2ad8a12e29bff24ec27d1ac66c0c3037d9fcf
+size 738884

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/lens.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/lens.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b1c717432ff7666398de58adec6a1b7e03a7e45aa155dbfe27a6152ef19663e5
+size 93684

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/m12_lens_holder.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/m12_lens_holder.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:031d5ffaf6247328cf6d020f6b6695ffb3f8d3f22cf923b85811351d89ecfd7c
+size 549684

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/motor_support.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/motor_support.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce0aa5bef82c7474512d302568c341b9769b3005e0bdb91a19c2eaaba6dad480
+size 180884

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/neck.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/neck.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6e86b886153be8a8a776c1cb219c074ee9e89c8bd431117662a2d9e504d7cb5
+size 73484

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/neck_pitch.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/neck_pitch.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a685ce65348ae4d0d49417c69a7a8871f8bbd54a6e3419362be9c334abd5d2ae
+size 356084

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/noenoeil.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/noenoeil.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e1167b3d5ad7fbbe6e63296bcd0c6b61556611e6bc1367b15ecfd27e3abb72f5
+size 49284

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/np_f970.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/np_f970.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e55a48281331b3b7b1a363d2e93b6012f37c52045b6dc922a149ca7c1b38388
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/pcb__raspberry_pi_zero_2_w.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/pcb__raspberry_pi_zero_2_w.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:802cc66fc5447c67fc642d1339e55160df10f2ad04a65efd130e35fb7b2d3c90
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/power_support.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/power_support.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ee45e397d3f3422f34940a4b61156c3c11c7e8c2b240451ce5f9ddd1622a130e
+size 641684

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/right_shell.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/right_shell.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3efba3e193cc6aa49d49a9c92cdded0504917397c9e2c5b8fe002a958e2f2d2b
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/seeed_bearing__configuration__22x16x4.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/seeed_bearing__configuration__22x16x4.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:295ee68ed9766c91fe06d3a2a49d39f7c2f56cc943395d293afdeb013123435e
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/seeed_bearing__configuration_default.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/seeed_bearing__configuration_default.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e815f3483a2e7b80844f3c0938a47e53db38b12faed9b2d364414c19e4322da4
+size 1048584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/soft_mouth_top.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/soft_mouth_top.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3c2b52b0b6e2ce944a1e1b5a0838e1216be1ad3a34c8cdf91be186e634aec57b
+size 393584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/sole_left.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/sole_left.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e028c8b09fecd4cb354d042bf7fd95a1a1bc2d524d760d62137fa8d74093fc23
+size 789484

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/sole_right.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/sole_right.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3f5068872f3add10eb967327651445bdfca635f5a8a01befa0ef05e462b72b4c
+size 795184

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/speaker.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/speaker.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:75a35f9bcf94cd8e52f99b3fd6ae667b48f52503f9075ee2f699eebe8e7b3ddf
+size 684

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/top_head_shell.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/top_head_shell.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d01f396f514c9d2185cf6b8250b1d8382ac3fa0702eb525bcb284f706196291
+size 806084

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/trunk_base.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/trunk_base.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:aa4f853ae555a8b765e585ce4519c0bbff325ce298ec15a1437792c52a0beac1
+size 184984

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/upper_leg_left.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/upper_leg_left.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8cb1c12dfa6d366a318bb1ec16f585427b9a185afeb7738d0a6f41f5db46a07d
+size 612584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/upper_leg_right.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/upper_leg_right.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5caf996cc3e151b01f393cdc6a6a6a940c1d86179d8b7c7f5f85cf1f1ac2fb63
+size 612584

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/upper_leg_rigidity_plate.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/upper_leg_rigidity_plate.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:231b3e5f1e24d146d735dc158cbcfec0c95a0d0ca8c500f61f04d15d0b665652
+size 180084

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/xl330.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/xl330.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96238ed0d020ce0009cf1a5aa4b6926176c800840318ee65e4375be2298d2744
+size 206384

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/yaw2roll.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/yaw2roll.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6c8f193ec7cb40be0f48eeb5fba81bce2c87f12e1aab3f77f1bc4981386e1495
+size 620284

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/yaw_roll_motion.stl
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/assets/yaw_roll_motion.stl
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0c9902dee19f06cdb7fa930292e0e1c91e2dc59baa971211495b58ff76c3c60
+size 290784

--- a/motrix_envs/src/motrix_envs/robot/assets/microduck/microduck.xml
+++ b/motrix_envs/src/motrix_envs/robot/assets/microduck/microduck.xml
@@ -1,0 +1,430 @@
+<?xml version="1.0" ?>
+<!-- Generated using onshape-to-robot -->
+<!-- Onshape https://cad.onshape.com/documents/804927696f06d877f3f1803e/w/5b75db19292e71970de02dee/e/ef6e972847fec8d82570b35e -->
+<mujoco model="microduck">
+  <compiler angle="radian" meshdir="assets" autolimits="true"/>
+  <default>
+    <default class="microduck">
+      <joint frictionloss="0.1" armature="0.005"/>
+      <position kp="50" dampratio="1"/>
+      <default class="visual">
+        <geom type="mesh" contype="0" conaffinity="0" group="2"/>
+      </default>
+      <default class="collision">
+        <geom group="3"/>
+      </default>
+    </default>
+  </default>
+  <!-- Additional joints_properties.xml -->
+  <default>
+    <default class="perfect_actuator">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.15" frictionloss="0.1" armature="0.001"/>
+      <position kp="10.0" kv="0.1" forcerange="-20.0 20.0"/>
+    </default>
+    <default class="chosen_actuator_old">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.048" frictionloss="0.006" armature="0.002"/>
+      <position kp="0.52" kv="0.0" forcerange="-0.91 0.91" ctrlrange="-10.0 10.0"/>
+    </default>
+    <default class="chosen_actuator_new">
+      <!-- removing contaminated data -->
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.041" frictionloss="0.032" armature="0.002"/>
+      <position kp="0.386" kv="0.0" forcerange="-0.67 0.67" ctrlrange="-10.0 10.0"/>
+    </default>
+    <default class="chosen_actuator_antoine">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.044" frictionloss="0.013" armature="0.0017"/>
+      <position kp="0.43" kv="0.0" forcerange="-0.75 0.75" ctrlrange="-10.0 10.0"/>
+    </default>
+    <default class="chosen_actuator">
+      <!-- marc -->
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.053" frictionloss="0.0048" armature="0.0018"/>
+      <!-- 200 kp -->
+      <position kp="0.55" kv="0.0" forcerange="-0.96 0.96" ctrlrange="-10.0 10.0"/>
+      <!-- 125 kp -->
+      <!-- <position kp="0.35" kv="0.0" forcerange="-0.96 0.96" ctrlrange="-10.0 10.0"/> -->
+    </default>
+    <default class="passive_wheel">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.0" frictionloss="0.0" armature="0.0001"/>
+    </default>
+    <default class="passive_joint">
+      <geom contype="0" conaffinity="0"/>
+      <joint damping="0.0" frictionloss="0.0" armature="0.0001"/>
+    </default>
+  </default>
+  <!-- Additional sensors.xml -->
+  <sensor>
+    <framequat name="orientation" objtype="site" noise="0.001" objname="imu"/>
+    <gyro name="angular-velocity" site="imu" noise="0.005"/>
+    <gyro name="imu_ang_vel" site="imu"/>
+    <velocimeter name="imu_lin_vel" site="imu"/>
+    <accelerometer name="imu_accel" site="imu"/>
+    <subtreeangmom name="root_angmom" body="trunk_base"/>
+  </sensor>
+  <!-- Additional additional.xml -->
+  <default>
+    <default class="self_collision_only">
+      <geom group="3" contype="2" conaffinity="2"/>
+    </default>
+    <equality solref="0.002 1" solimp="0.99 0.999 0.0005 0.5 2"/>
+  </default>
+  <!-- <contact> -->
+  <!-- Jaw collision mesh overlaps the bottom head shell by ~2cm because the closed -->
+  <!-- loop linkage positions it inside the head. Without these excludes the -->
+  <!-- self-collision sensor reports a constant 2 contacts, giving a -->
+  <!-- permanent ~-2.0 reward penalty in the standup env. -->
+  <!-- <exclude body1="jaw" body2="bottom_head_shell"/> -->
+  <!-- </contact> -->
+  <worldbody>
+    <!-- Link trunk_base -->
+    <body name="trunk_base" pos="0 0 0.12" quat="1 0 0 0" childclass="microduck">
+      <freejoint name="trunk_base_freejoint"/>
+      <inertial pos="-0.0226332 -2.70828e-05 0.00280064" mass="0.199224" fullinertia="0.000123975 0.000145931 0.000115351 7.1651e-08 -2.06915e-05 1.32429e-07"/>
+      <!-- Termination capsule for the humanoid walk task; not present in upstream robot_walk.xml. -->
+      <geom name="trunk_collision" class="collision" type="capsule" fromto="-0.015 0 -0.02 0.015 0 0.02" size="0.015"/>
+      <!-- Part seeed_bearing__configuration__22x16x4 -->
+      <geom type="mesh" class="visual" pos="0.006 0.0175 -0.005" quat="1 -0 -0 0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+      <!-- Part right_shell -->
+      <geom type="mesh" class="visual" pos="0.004 -0.0005 -0.0175" quat="0.707107 0 0 0.707107" mesh="right_shell" material="right_shell_material"/>
+      <!-- Part banana_pcb_locker -->
+      <geom type="mesh" class="visual" pos="0.0042 0 -0.0175215" quat="0.707107 -0 0 0.707107" mesh="banana_pcb_locker" material="banana_pcb_locker_material"/>
+      <!-- Part trunk_base -->
+      <geom type="mesh" class="visual" pos="0.004 -0 -0.0175" quat="0.707107 -0 -0 0.707107" mesh="trunk_base" material="trunk_base_material"/>
+      <!-- Part xl330 -->
+      <geom type="mesh" class="visual" pos="0.006 0.0175 0.0115" quat="0 -0.707107 0 -0.707107" mesh="xl330" material="xl330_material"/>
+      <!-- Part power_support -->
+      <geom type="mesh" class="visual" pos="0.004 -0 -0.0175215" quat="0.707107 -0 -0 0.707107" mesh="power_support" material="power_support_material"/>
+      <geom type="mesh" class="self_collision_only" pos="0.004 -0 -0.0175215" quat="0.707107 -0 -0 0.707107" mesh="power_support" material="power_support_material"/>
+      <!-- Part np_f970 -->
+      <geom type="mesh" class="visual" pos="-0.0359693 0 -0.00385049" quat="0.00617059 0.70708 -0.70708 -0.00617059" mesh="np_f970" material="np_f970_material"/>
+      <!-- Part xl330_2 -->
+      <geom type="mesh" class="visual" pos="0.006 -0.0175 0.0115" quat="0 -0.707107 0 -0.707107" mesh="xl330" material="xl330_material"/>
+      <!-- Part left_shell -->
+      <geom type="mesh" class="visual" pos="0.004 -0 -0.0175785" quat="0.707107 -0 -0 0.707107" mesh="left_shell" material="left_shell_material"/>
+      <!-- Part seeed_bearing__configuration__22x16x4_2 -->
+      <geom type="mesh" class="visual" pos="0.006 -0.0175 -0.005" quat="1 -0 -0 0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+      <!-- Frame imu -->
+      <site group="3" name="imu" pos="-0.021 6.64098e-05 -0.0146984" quat="1 -0 -0 -0"/>
+      <!-- Link yaw2roll -->
+      <body name="yaw2roll" pos="0.006 0.0175 -0.005" quat="0 -0.707107 -0.707107 -0">
+        <!-- Joint from trunk_base to yaw2roll -->
+        <joint axis="0 0 1" name="left_hip_yaw" type="hinge" range="-0.4363323129985824 0.5235987755982988" class="chosen_actuator"/>
+        <inertial pos="-8.8e-11 0.00099414 0.0168917" mass="0.0230406" fullinertia="4.1964e-06 3.41752e-06 2.3265e-06 -0 -0 -5.0881e-08"/>
+        <!-- Part yaw2roll -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 1 0 0" mesh="yaw2roll" material="yaw2roll_material"/>
+        <!-- Part xl330_3 -->
+        <geom type="mesh" class="visual" pos="-0 -0 0.0125" quat="0 -0.707107 0.707107 -0" mesh="xl330" material="xl330_material"/>
+        <!-- Part seeed_bearing__configuration__22x16x4_3 -->
+        <geom type="mesh" class="visual" pos="-0 0.0165 0.0125" quat="0.5 0.5 0.5 -0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+        <!-- Part bearing_roll -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 -1 -0 -0" mesh="bearing_roll" material="bearing_roll_material"/>
+        <!-- Link hip_l -->
+        <body name="hip_l" pos="0 0.0165 0.0125" quat="0.707107 -0.707107 0 -0">
+          <!-- Joint from yaw2roll to hip_l -->
+          <joint axis="0 0 1" name="left_hip_roll" type="hinge" range="-0.3839724354386992 0.38397243543880577" class="chosen_actuator"/>
+          <inertial pos="0.014815 1.6179e-08 -0.00829992" mass="0.00618934" fullinertia="8.60626e-07 1.15753e-06 6.51588e-07 1e-12 3.89882e-07 -1e-12"/>
+          <!-- Part seeed_bearing__configuration__22x16x4_4 -->
+          <geom type="mesh" class="visual" pos="0.021 0 -0.0185" quat="0.5 0.5 0.5 0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+          <!-- Part hip_l -->
+          <geom type="mesh" class="visual" pos="-0.0175 0 -0.0185" quat="0.707107 -0.707107 0 0" mesh="hip_l" material="hip_l_material"/>
+          <!-- Link upper_leg_left -->
+          <body name="upper_leg_left" pos="0.025 0 -0.0185" quat="0.5 -0.5 0.5 -0.5">
+            <!-- Joint from hip_l to upper_leg_left -->
+            <joint axis="0 0 1" name="left_hip_pitch" type="hinge" range="-1.570796326794949 1.5707963267948442" class="chosen_actuator"/>
+            <inertial pos="0.006766 0.0228838 0.0134531" mass="0.0482067" fullinertia="1.68753e-05 1.03691e-05 1.98269e-05 -4.41852e-06 2.27982e-07 3.89298e-07"/>
+            <!-- Part upper_leg_left -->
+            <geom type="mesh" class="visual" pos="-0 -0 -0.0425" quat="0.5 -0.5 -0.5 -0.5" mesh="upper_leg_left" material="upper_leg_left_material"/>
+            <!-- Part xl330_4 -->
+            <geom type="mesh" class="visual" pos="0.022 0.0357771 0.0125" quat="0 0.707107 0 0.707107" mesh="xl330" material="xl330_material"/>
+            <!-- Part upper_leg_rigidity_plate -->
+            <geom type="mesh" class="visual" pos="0 0 -0.0425" quat="0.5 -0.5 -0.5 -0.5" mesh="upper_leg_rigidity_plate" material="upper_leg_rigidity_plate_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_5 -->
+            <geom type="mesh" class="visual" pos="0.022 0.0357771 -0.004" quat="0 0 -0 1" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Part xl330_5 -->
+            <geom type="mesh" class="visual" pos="0 -0 0.0125" quat="0.5 0.5 -0.5 0.5" mesh="xl330" material="xl330_material"/>
+            <!-- Link leg -->
+            <body name="leg" pos="0.022 0.0357771 -0.004" quat="0 0.707107 0.707107 0">
+              <!-- Joint from upper_leg_left to leg -->
+              <joint axis="0 0 1" name="left_knee" type="hinge" range="-1.5707963267948983 1.5707963267948948" class="chosen_actuator"/>
+              <inertial pos="-1.52e-10 0.0318937 -0.00953505" mass="0.0215844" fullinertia="5.25056e-06 2.15507e-06 4.33925e-06 -1e-12 0 7.65005e-07"/>
+              <!-- Part leg -->
+              <geom type="mesh" class="visual" pos="-0.022 0.0357771 0.0385" quat="0.5 0.5 0.5 -0.5" mesh="leg" material="leg_material"/>
+              <geom type="mesh" class="self_collision_only" pos="-0.022 0.0357771 0.0385" quat="0.5 0.5 0.5 -0.5" mesh="leg" material="leg_material"/>
+              <!-- Part xl330_6 -->
+              <geom type="mesh" class="visual" pos="-0 0.042 -0.0115" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+              <!-- Link ankle_left -->
+              <body name="ankle_left" pos="-0 0.042 -0.026" quat="0 -1 -0 0">
+                <!-- Joint from leg to ankle_left -->
+                <joint axis="0 0 1" name="left_ankle" type="hinge" range="-1.5707963267949063 1.5707963267948868" class="chosen_actuator"/>
+                <inertial pos="-0.00615742 -0.0137483 -0.0156585" mass="0.0300246" fullinertia="5.91525e-06 1.11534e-05 7.74016e-06 -2.05354e-07 8.218e-08 5.6722e-08"/>
+                <!-- Part sole_left -->
+                <geom type="mesh" class="visual" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="sole_left" material="sole_left_material"/>
+                <geom type="mesh" name="left_foot_collision" class="collision" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="sole_left" material="sole_left_material"/>
+                <!-- Part foot_left -->
+                <geom type="mesh" class="visual" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="foot_left" material="foot_left_material"/>
+                <!-- Part seeed_bearing__configuration_default -->
+                <geom type="mesh" class="visual" pos="0 0 -0.0322" quat="0 0 0 1" mesh="seeed_bearing__configuration_default" material="seeed_bearing__configuration_default_material"/>
+                <!-- Part ankle_left -->
+                <geom type="mesh" class="visual" pos="-0.022 0.00622291 -0.0647" quat="0.5 -0.5 -0.5 -0.5" mesh="ankle_left" material="ankle_left_material"/>
+                <!-- Frame left_foot -->
+                <site group="3" name="left_foot" pos="-0 -0.0238146 -0.0140852" quat="0 -0 -0.707107 -0.707107"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <!-- Link neck -->
+      <body name="neck" pos="0.026 0.0145 0.0324215" quat="0 0 0.707107 -0.707107">
+        <!-- Joint from trunk_base to neck -->
+        <joint axis="0 0 1" name="neck_pitch" type="hinge" range="-1.5707963267948974 1.0471975511965967" class="chosen_actuator"/>
+        <inertial pos="-0 -0.025 0.0141665" mass="0.0368414" fullinertia="1.72925e-05 3.12694e-06 1.63707e-05 -0 0 -0"/>
+        <!-- Part neck -->
+        <geom type="mesh" class="visual" pos="0.022 0.05 0.028" quat="0.5 0.5 0.5 -0.5" mesh="neck" material="neck_material"/>
+        <!-- Part xl330_7 -->
+        <geom type="mesh" class="visual" pos="0 0 0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+        <!-- Part xl330_8 -->
+        <geom type="mesh" class="visual" pos="-0 -0.05 0.0145" quat="0.5 0.5 -0.5 0.5" mesh="xl330" material="xl330_material"/>
+        <!-- Part neck_2 -->
+        <geom type="mesh" class="visual" pos="0.022 0.05 0.003" quat="0.5 0.5 0.5 -0.5" mesh="neck" material="neck_material"/>
+        <!-- Link neck_pitch -->
+        <body name="neck_pitch" pos="-0 -0.05 0" quat="0 1 -0 -0">
+          <!-- Joint from neck to neck_pitch -->
+          <joint axis="0 0 1" name="head_pitch" type="hinge" range="-1.5707963267948966 1.5707963267948966" class="chosen_actuator"/>
+          <inertial pos="-6.533e-09 0.0116641 -0.0145" mass="0.00572" fullinertia="1.09186e-06 9.66855e-07 5.12111e-07 0 0 0"/>
+          <!-- Part neck_pitch -->
+          <geom type="mesh" class="visual" pos="-0 0.0287931 -0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="neck_pitch" material="neck_pitch_material"/>
+          <!-- Part seeed_bearing__configuration__22x16x4_6 -->
+          <geom type="mesh" class="visual" pos="-0 0.0207931 -0.0145" quat="0.707107 0.707107 -0 0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+          <!-- Link yaw_roll_motion -->
+          <body name="yaw_roll_motion" pos="-0 0.0186931 -0.0145" quat="0 -0 -0.707107 -0.707107">
+            <!-- Joint from neck_pitch to yaw_roll_motion -->
+            <joint axis="0 0 1" name="head_yaw" type="hinge" range="-2.9670597283903613 2.9670597283903595" class="chosen_actuator"/>
+            <inertial pos="-0.000166657 -0.00500964 0.0178065" mass="0.0486" fullinertia="6.97903e-06 8.10293e-06 9.57884e-06 3.21657e-07 -3.4797e-08 3.4295e-07"/>
+            <!-- Part yaw_roll_motion -->
+            <geom type="mesh" class="visual" pos="0 0 0.01" quat="0.707107 0 0 0.707107" mesh="yaw_roll_motion" material="yaw_roll_motion_material"/>
+            <!-- Part xl330_9 -->
+            <geom type="mesh" class="visual" pos="0 0 0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_7 -->
+            <geom type="mesh" class="visual" pos="-0.016 0 0.0145" quat="0.707107 -0 -0.707107 -0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_8 -->
+            <geom type="mesh" class="visual" pos="0.018 0 0.0145" quat="0.707107 0 -0.707107 -0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Link jaw_soft -->
+            <body name="jaw_soft" pos="-0.0179 0 0.0145" quat="0.707107 0 -0.707107 -0">
+              <!-- Joint from yaw_roll_motion to jaw_soft -->
+              <joint axis="0 0 1" name="head_roll" type="hinge" range="-0.43633231299858327 0.4363323129985815" class="chosen_actuator"/>
+              <inertial pos="0.00460523 0.00120047 -0.0324761" mass="0.188766" fullinertia="0.000320811 0.0002541 0.000149882 -6.32293e-07 6.57153e-06 4.18477e-06"/>
+              <!-- Part lens -->
+              <geom type="mesh" class="visual" pos="0.0155 -9.13778e-05 -0.05548" quat="0.5 -0.5 0.5 -0.5" mesh="lens" material="lens_material"/>
+              <!-- Part face_part -->
+              <geom type="mesh" class="visual" pos="-0.0045 -9.13778e-05 -0.0178" quat="0.5 0.5 0.5 0.5" mesh="face_part" material="face_part_material"/>
+              <!-- Part xl330_10 -->
+              <geom type="mesh" class="visual" pos="0.003 0.0255 -0.018" quat="0.707107 0 -0 -0.707107" mesh="xl330" material="xl330_material"/>
+              <!-- Part jaw_soft -->
+              <geom type="mesh" class="visual" pos="-0.0046 0 -0.0179996" quat="0.5 0.5 0.5 0.5" mesh="jaw_soft" material="jaw_soft_material"/>
+              <!-- Part motor_support -->
+              <geom type="mesh" class="visual" pos="-0.0045 -0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="motor_support" material="motor_support_material"/>
+              <!-- Part top_head_shell -->
+              <geom type="mesh" class="visual" pos="-0.0045 -0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="top_head_shell" material="top_head_shell_material"/>
+              <!-- Part xl330_11 -->
+              <geom type="mesh" class="visual" pos="0 0 0.0145" quat="0.5 -0.5 -0.5 -0.5" mesh="xl330" material="xl330_material"/>
+              <!-- Part seeed_bearing__configuration_default_2 -->
+              <geom type="mesh" class="visual" pos="0.0032 -0.04 -0.018" quat="0.5 -0.5 0.5 0.5" mesh="seeed_bearing__configuration_default" material="seeed_bearing__configuration_default_material"/>
+              <!-- Part elec_rpi_robot_hat_pcb -->
+              <geom type="mesh" class="visual" pos="0.02694 0.0289936 -0.0519" quat="0.707107 0 -0 -0.707107" mesh="elec_rpi_robot_hat_pcb" material="elec_rpi_robot_hat_pcb_material"/>
+              <!-- Part soft_mouth_top -->
+              <geom type="mesh" class="visual" pos="-0.00420071 1.7776e-08 -0.0180814" quat="0.5 0.5 0.5 0.5" mesh="soft_mouth_top" material="soft_mouth_top_material"/>
+              <!-- Part noenoeil -->
+              <geom type="mesh" class="visual" pos="-0.0045 -9.13778e-05 -0.0178" quat="0.5 0.5 0.5 0.5" mesh="noenoeil" material="noenoeil_material"/>
+              <!-- Part jaw -->
+              <geom type="mesh" class="visual" pos="-0.0045 -0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="jaw" material="jaw_material"/>
+              <!-- Part bottom_head_shell -->
+              <geom type="mesh" class="visual" pos="-0.0043 -0 -0.018" quat="0.5 0.5 0.5 0.5" mesh="bottom_head_shell" material="bottom_head_shell_material"/>
+              <!-- Part m12_lens_holder -->
+              <geom type="mesh" class="visual" pos="0.0155 -9.13778e-05 -0.05558" quat="0.5 -0.5 0.5 -0.5" mesh="m12_lens_holder" material="m12_lens_holder_material"/>
+              <!-- Part pcb__raspberry_pi_zero_2_w -->
+              <geom type="mesh" class="visual" pos="0.015435 -1.13778e-05 -0.06001" quat="0.5 -0.5 -0.5 0.5" mesh="pcb__raspberry_pi_zero_2_w" material="pcb__raspberry_pi_zero_2_w_material"/>
+              <!-- Part speaker -->
+              <geom type="mesh" class="visual" pos="0.01 -0.016786 0.0260226" quat="0.5 0.5 0.5 0.5" mesh="speaker" material="speaker_material"/>
+              <!-- Frame head_camera -->
+              <site group="3" name="head_camera" pos="0.0155 -9.13778e-05 -0.0733" quat="0.707107 -0 0.707107 0"/>
+              <camera name="head_camera" pos="0.0155 -9.13778e-05 -0.0733" quat="0 0 -1 0"/>
+              <!-- Frame tof -->
+              <site group="3" name="tof" pos="0.0135 0.0224086 -0.0733" quat="0.707107 -0 0.707107 0"/>
+              <!-- Frame head_imu -->
+              <site group="3" name="head_imu" pos="0.0152323 0.000111069 -0.05106" quat="1 0 -0 0"/>
+              <!-- Frame mouth_tip -->
+              <site group="3" name="mouth_tip" pos="-0.00809334 -0 -0.0777383" quat="0.704015 -0 0.710185 0"/>
+            </body>
+          </body>
+        </body>
+      </body>
+      <!-- Link bearing_roll -->
+      <body name="bearing_roll" pos="0.006 -0.0175 -0.005" quat="0 -0.707107 -0.707107 0">
+        <!-- Joint from trunk_base to bearing_roll -->
+        <joint axis="0 0 1" name="right_hip_yaw" type="hinge" range="-0.523598775598297 0.43633231299858416" class="chosen_actuator"/>
+        <inertial pos="-8.8e-11 0.00099414 0.0168917" mass="0.0230406" fullinertia="4.1964e-06 3.41752e-06 2.3265e-06 -0 -0 -5.0881e-08"/>
+        <!-- Part yaw2roll_2 -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 1 0 0" mesh="yaw2roll" material="yaw2roll_material"/>
+        <!-- Part xl330_12 -->
+        <geom type="mesh" class="visual" pos="-0 -0 0.0125" quat="0 -0.707107 0.707107 0" mesh="xl330" material="xl330_material"/>
+        <!-- Part bearing_roll_2 -->
+        <geom type="mesh" class="visual" pos="-0.0175 -0.002 0.0125" quat="0 1 0 0" mesh="bearing_roll" material="bearing_roll_material"/>
+        <!-- Part seeed_bearing__configuration__22x16x4_9 -->
+        <geom type="mesh" class="visual" pos="-0 0.0165 0.0125" quat="0.5 0.5 0.5 -0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+        <!-- Link hip_l_2 -->
+        <body name="hip_l_2" pos="-0 0.0165 0.0125" quat="0 0 0.707107 0.707107">
+          <!-- Joint from bearing_roll to hip_l_2 -->
+          <joint axis="0 0 1" name="right_hip_roll" type="hinge" range="-0.3839724354387507 0.38397243543875426" class="chosen_actuator"/>
+          <inertial pos="0.014815 1.6212e-08 -0.00829992" mass="0.00618934" fullinertia="8.60626e-07 1.15753e-06 6.51588e-07 1e-12 3.89882e-07 -1e-12"/>
+          <!-- Part hip_l_2 -->
+          <geom type="mesh" class="visual" pos="-0.0175 0 -0.0185" quat="0.707107 -0.707107 -0 -0" mesh="hip_l" material="hip_l_material"/>
+          <!-- Part seeed_bearing__configuration__22x16x4_10 -->
+          <geom type="mesh" class="visual" pos="0.025 0 -0.0185" quat="0.5 0.5 -0.5 -0.5" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+          <!-- Link upper_leg_right -->
+          <body name="upper_leg_right" pos="0.025 0 -0.0185" quat="0.5 -0.5 0.5 -0.5">
+            <!-- Joint from hip_l_2 to upper_leg_right -->
+            <joint axis="0 0 1" name="right_hip_pitch" type="hinge" range="-1.57079632679494 1.570796326794853" class="chosen_actuator"/>
+            <inertial pos="-0.006766 0.0228838 0.0134531" mass="0.0482067" fullinertia="1.68753e-05 1.03691e-05 1.98269e-05 4.41852e-06 -2.27982e-07 3.89298e-07"/>
+            <!-- Part xl330_13 -->
+            <geom type="mesh" class="visual" pos="-0.022 0.0357771 0.0125" quat="0.707107 -0 -0.707107 -0" mesh="xl330" material="xl330_material"/>
+            <!-- Part seeed_bearing__configuration__22x16x4_11 -->
+            <geom type="mesh" class="visual" pos="-0.022 0.0357771 0" quat="0 1 -0 -0" mesh="seeed_bearing__configuration__22x16x4" material="seeed_bearing__configuration__22x16x4_material"/>
+            <!-- Part upper_leg_rigidity_plate_2 -->
+            <geom type="mesh" class="visual" pos="-0 -0 0.0435" quat="0.5 -0.5 0.5 0.5" mesh="upper_leg_rigidity_plate" material="upper_leg_rigidity_plate_material"/>
+            <!-- Part upper_leg_right -->
+            <geom type="mesh" class="visual" pos="-0 -0 -0.0425" quat="0.5 -0.5 0.5 0.5" mesh="upper_leg_right" material="upper_leg_right_material"/>
+            <!-- Part xl330_14 -->
+            <geom type="mesh" class="visual" pos="-0 -0 0.0125" quat="0.5 0.5 -0.5 0.5" mesh="xl330" material="xl330_material"/>
+            <!-- Link leg_2 -->
+            <body name="leg_2" pos="-0.022 0.0357771 -0.004" quat="0 1 -0 -0">
+              <!-- Joint from upper_leg_right to leg_2 -->
+              <joint axis="0 0 1" name="right_knee" type="hinge" range="-1.5707963267949339 1.5707963267948593" class="chosen_actuator"/>
+              <inertial pos="-0.0318937 -1.52e-10 -0.00953505" mass="0.0215844" fullinertia="2.15507e-06 5.25056e-06 4.33925e-06 1e-12 -7.65005e-07 0"/>
+              <!-- Part xl330_15 -->
+              <geom type="mesh" class="visual" pos="-0.042 0 -0.0115" quat="0.707107 -0 -0.707107 -0" mesh="xl330" material="xl330_material"/>
+              <!-- Part leg_2 -->
+              <geom type="mesh" class="visual" pos="-0.0357771 -0.022 0.0385" quat="0.707107 0 0.707107 -0" mesh="leg" material="leg_material"/>
+              <geom type="mesh" class="self_collision_only" pos="-0.0357771 -0.022 0.0385" quat="0.707107 0 0.707107 -0" mesh="leg" material="leg_material"/>
+              <!-- Link ankle_right -->
+              <body name="ankle_right" pos="-0.042 0 -0.026" quat="0 -0.707107 -0.707107 0">
+                <!-- Joint from leg_2 to ankle_right -->
+                <joint axis="0 0 1" name="right_ankle" type="hinge" range="-1.5707963267949028 1.5707963267948903" class="chosen_actuator"/>
+                <inertial pos="0.00615539 -0.0137482 -0.0156566" mass="0.0300251" fullinertia="5.91534e-06 1.11534e-05 7.74015e-06 2.04877e-07 -8.2467e-08 5.7017e-08"/>
+                <!-- Part ankle_right -->
+                <geom type="mesh" class="visual" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="ankle_right" material="ankle_right_material"/>
+                <!-- Part sole_right -->
+                <geom type="mesh" class="visual" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="sole_right" material="sole_right_material"/>
+                <geom type="mesh" name="right_foot_collision" class="collision" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="sole_right" material="sole_right_material"/>
+                <!-- Part seeed_bearing__configuration_default_3 -->
+                <geom type="mesh" class="visual" pos="0 -0 -0.0292" quat="0 -1 -0 -0" mesh="seeed_bearing__configuration_default" material="seeed_bearing__configuration_default_material"/>
+                <!-- Part foot_right -->
+                <geom type="mesh" class="visual" pos="0.022 0.00622291 -0.0647" quat="0.5 -0.5 0.5 0.5" mesh="foot_right" material="foot_right_material"/>
+                <!-- Frame right_foot -->
+                <site group="3" name="right_foot" pos="0 -0.0238146 -0.0140852" quat="0.707107 -0.707107 -0 0"/>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+  <asset>
+    <mesh file="right_shell.stl"/>
+    <mesh file="speaker.stl"/>
+    <mesh file="banana_pcb_locker.stl"/>
+    <mesh file="top_head_shell.stl"/>
+    <mesh file="bearing_roll.stl"/>
+    <mesh file="ankle_left.stl"/>
+    <mesh file="upper_leg_rigidity_plate.stl"/>
+    <mesh file="neck_pitch.stl"/>
+    <mesh file="noenoeil.stl"/>
+    <mesh file="face_part.stl"/>
+    <mesh file="pcb__raspberry_pi_zero_2_w.stl"/>
+    <mesh file="foot_right.stl"/>
+    <mesh file="seeed_bearing__configuration__22x16x4.stl"/>
+    <mesh file="elec_rpi_robot_hat_pcb.stl"/>
+    <mesh file="xl330.stl"/>
+    <mesh file="jaw_soft.stl"/>
+    <mesh file="hip_l.stl"/>
+    <mesh file="bottom_head_shell.stl"/>
+    <mesh file="yaw2roll.stl"/>
+    <mesh file="seeed_bearing__configuration_default.stl"/>
+    <mesh file="ankle_right.stl"/>
+    <mesh file="motor_support.stl"/>
+    <mesh file="foot_left.stl"/>
+    <mesh file="upper_leg_right.stl"/>
+    <mesh file="power_support.stl"/>
+    <mesh file="np_f970.stl"/>
+    <mesh file="neck.stl"/>
+    <mesh file="yaw_roll_motion.stl"/>
+    <mesh file="lens.stl"/>
+    <mesh file="sole_left.stl"/>
+    <mesh file="upper_leg_left.stl"/>
+    <mesh file="trunk_base.stl"/>
+    <mesh file="left_shell.stl"/>
+    <mesh file="sole_right.stl"/>
+    <mesh file="jaw.stl"/>
+    <mesh file="leg.stl"/>
+    <mesh file="soft_mouth_top.stl"/>
+    <mesh file="m12_lens_holder.stl"/>
+    <material name="seeed_bearing__configuration__22x16x4_material" rgba="0.811765 0.858824 0.898039 1"/>
+    <material name="right_shell_material" rgba="0.85098 0.85098 0.839216 1"/>
+    <material name="banana_pcb_locker_material" rgba="0.647059 0.647059 0.647059 1"/>
+    <material name="trunk_base_material" rgba="0.129412 0.152941 0.129412 1"/>
+    <material name="xl330_material" rgba="0.286275 0.286275 0.286275 1"/>
+    <material name="power_support_material" rgba="0.67451 0.639216 0.603922 1"/>
+    <material name="np_f970_material" rgba="0.301961 0.301961 0.301961 1"/>
+    <material name="left_shell_material" rgba="0.8 0.8 0.8 1"/>
+    <material name="yaw2roll_material" rgba="0.129412 0.152941 0.129412 1"/>
+    <material name="bearing_roll_material" rgba="0.129412 0.152941 0.129412 1"/>
+    <material name="hip_l_material" rgba="0.67451 0.639216 0.603922 1"/>
+    <material name="upper_leg_left_material" rgba="0.85098 0.85098 0.839216 1"/>
+    <material name="upper_leg_rigidity_plate_material" rgba="0.67451 0.639216 0.603922 1"/>
+    <material name="leg_material" rgba="0.67451 0.639216 0.603922 1"/>
+    <material name="sole_left_material" rgba="0.956863 0.686275 0.137255 1"/>
+    <material name="foot_left_material" rgba="1 0.403922 0.121569 1"/>
+    <material name="seeed_bearing__configuration_default_material" rgba="0.811765 0.858824 0.898039 1"/>
+    <material name="ankle_left_material" rgba="1 0.403922 0.121569 1"/>
+    <material name="neck_material" rgba="0.67451 0.639216 0.603922 1"/>
+    <material name="neck_pitch_material" rgba="0.34902 0.376471 0.4 1"/>
+    <material name="yaw_roll_motion_material" rgba="0.129412 0.152941 0.129412 1"/>
+    <material name="lens_material" rgba="0.262745 0.282353 0.301961 1"/>
+    <material name="face_part_material" rgba="0.67451 0.639216 0.603922 1"/>
+    <material name="jaw_soft_material" rgba="0.85098 0.756863 0.866667 1"/>
+    <material name="motor_support_material" rgba="0.129412 0.152941 0.129412 1"/>
+    <material name="top_head_shell_material" rgba="0.85098 0.85098 0.839216 1"/>
+    <material name="elec_rpi_robot_hat_pcb_material" rgba="0.313725 0.486275 0.411765 1"/>
+    <material name="soft_mouth_top_material" rgba="0.85098 0.756863 0.866667 1"/>
+    <material name="noenoeil_material" rgba="0.956863 0.686275 0.137255 1"/>
+    <material name="jaw_material" rgba="1 0.403922 0.121569 1"/>
+    <material name="bottom_head_shell_material" rgba="1 0.403922 0.121569 1"/>
+    <material name="m12_lens_holder_material" rgba="0.262745 0.282353 0.301961 1"/>
+    <material name="pcb__raspberry_pi_zero_2_w_material" rgba="0.498039 0.498039 0.498039 1"/>
+    <material name="speaker_material" rgba="0.294118 0.290196 0.290196 1"/>
+    <material name="upper_leg_right_material" rgba="0.85098 0.85098 0.839216 1"/>
+    <material name="ankle_right_material" rgba="1 0.403922 0.121569 1"/>
+    <material name="sole_right_material" rgba="0.956863 0.686275 0.137255 1"/>
+    <material name="foot_right_material" rgba="1 0.403922 0.121569 1"/>
+  </asset>
+  <actuator>
+    <position class="chosen_actuator" name="left_hip_yaw" joint="left_hip_yaw"/>
+    <position class="chosen_actuator" name="left_hip_roll" joint="left_hip_roll"/>
+    <position class="chosen_actuator" name="left_hip_pitch" joint="left_hip_pitch"/>
+    <position class="chosen_actuator" name="left_knee" joint="left_knee"/>
+    <position class="chosen_actuator" name="left_ankle" joint="left_ankle"/>
+    <position class="chosen_actuator" name="neck_pitch" joint="neck_pitch"/>
+    <position class="chosen_actuator" name="head_pitch" joint="head_pitch"/>
+    <position class="chosen_actuator" name="head_yaw" joint="head_yaw"/>
+    <position class="chosen_actuator" name="head_roll" joint="head_roll"/>
+    <position class="chosen_actuator" name="right_hip_yaw" joint="right_hip_yaw"/>
+    <position class="chosen_actuator" name="right_hip_roll" joint="right_hip_roll"/>
+    <position class="chosen_actuator" name="right_hip_pitch" joint="right_hip_pitch"/>
+    <position class="chosen_actuator" name="right_knee" joint="right_knee"/>
+    <position class="chosen_actuator" name="right_ankle" joint="right_ankle"/>
+  </actuator>
+  <equality/>
+</mujoco>

--- a/motrix_envs/src/motrix_envs/robot/microduck.py
+++ b/motrix_envs/src/motrix_envs/robot/microduck.py
@@ -1,0 +1,96 @@
+# Copyright Motphys Technology Co., Ltd. 2025, 2026
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+from motrix_env_core.config import configclass
+from motrix_env_core.config.scene import KeyPoseCfg, MjcfFileCfg
+from motrix_envs.robot.humanoid import HumanoidRobotCfg
+
+MICRODUCK_ASSET_DIR = Path(__file__).parent / "assets" / "microduck"
+_MICRODUCK_MJCF = MICRODUCK_ASSET_DIR / "microduck.xml"
+
+
+@configclass(kw_only=True)
+class Microduck(HumanoidRobotCfg):
+    """Built-in Pollen Robotics Microduck 14-DoF biped robot configuration.
+
+    Ported from https://github.com/pollen-robotics/microduck_rl (Apache-2.0
+    code; mesh assets are CC BY-SA-NC, see the asset directory README).
+    """
+
+    model: MjcfFileCfg = MjcfFileCfg(file=_MICRODUCK_MJCF)
+    base_link_name: str = "trunk_base"
+    left_foot_link_name: str = "ankle_left"
+    right_foot_link_name: str = "ankle_right"
+    key_pose: KeyPoseCfg = KeyPoseCfg(
+        joint_names=[
+            "left_hip_yaw",
+            "left_hip_roll",
+            "left_hip_pitch",
+            "left_knee",
+            "left_ankle",
+            "neck_pitch",
+            "head_pitch",
+            "head_yaw",
+            "head_roll",
+            "right_hip_yaw",
+            "right_hip_roll",
+            "right_hip_pitch",
+            "right_knee",
+            "right_ankle",
+        ],
+        poses={
+            # Upstream keyframe "STAND" (trunk at z=0.12).
+            "default": [
+                0.0,
+                -0.08726646259971647,
+                -0.457924,
+                -0.004940,
+                0.452984,
+                0.3490658503988659,
+                0.3490658503988659,
+                0.0,
+                0.0,
+                0.0,
+                0.08726646259971647,
+                0.457924,
+                0.004940,
+                -0.452984,
+            ],
+            # Upstream keyframe "SIT" (trunk at z=0.07).
+            "sit": [
+                0.0,
+                0.0,
+                -0.5236,
+                1.0472,
+                0.0,
+                0.5,
+                1.6,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                0.5236,
+                -1.0472,
+                0.0,
+            ],
+            # Upstream keyframe "FOLD" (trunk at z=0.07).
+            "fold": [
+                0.0,
+                0.0,
+                1.5708,
+                1.5708,
+                0.0,
+                1.0,
+                1.0,
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                -1.5708,
+                -1.5708,
+                0.0,
+            ],
+        },
+    )

--- a/motrix_envs/tests/test_humanoid_walk.py
+++ b/motrix_envs/tests/test_humanoid_walk.py
@@ -16,6 +16,10 @@ from motrix_envs.locomotion.humanoid.g1 import (
     make_g129dof_walk_rough_cfg,
 )
 from motrix_envs.locomotion.humanoid.k1 import make_k1_walk_flat_cfg, make_k1_walk_rough_cfg
+from motrix_envs.locomotion.humanoid.microduck import (
+    make_microduck_walk_flat_cfg,
+    make_microduck_walk_rough_cfg,
+)
 from motrix_envs.locomotion.humanoid.walk_np import HumanoidVelocityTrackingEnv
 
 
@@ -28,6 +32,8 @@ from motrix_envs.locomotion.humanoid.walk_np import HumanoidVelocityTrackingEnv
         ("dex-evt-walk-rough", 23, 82, 85),
         ("k1-walk-flat", 22, 79, 82),
         ("k1-walk-rough", 22, 79, 82),
+        ("microduck-walk-flat", 14, 55, 58),
+        ("microduck-walk-rough", 14, 55, 58),
     ],
 )
 def test_walk_presets_use_shared_humanoid_env(env_name, action_dim, policy_dim, value_dim):
@@ -76,12 +82,27 @@ def test_k1_walk_uses_shared_reward_scales_and_named_contact_termination():
     np.testing.assert_allclose(quantities.foot_clearance, 0.00716, atol=2e-3)
 
 
+def test_microduck_walk_uses_named_contact_termination():
+    walk_cfg = make_microduck_walk_flat_cfg()
+    env = HumanoidVelocityTrackingEnv(walk_cfg, num_envs=2)
+    env.init_state()
+    quantities = env._state_quantities(slice(None), np.arange(2, dtype=np.int64))
+
+    assert env._num_termination_pairs == 1
+    np.testing.assert_allclose(quantities.foot_clearance, 0.0, atol=4e-3)
+    # Microduck ankle-link frames are ~90 degrees away from world-aligned, so
+    # the foot-orientation penalty must be measured against the default-pose
+    # reference: it is zero at the default stance for any link orientation.
+    np.testing.assert_allclose(env._r_feet_ori(quantities), 0.0, atol=1e-3)
+
+
 @pytest.mark.parametrize(
     ("make_flat_cfg", "make_rough_cfg"),
     [
         (make_g129dof_walk_flat_cfg, make_g129dof_walk_rough_cfg),
         (make_dex_evt_walk_flat_cfg, make_dex_evt_walk_rough_cfg),
         (make_k1_walk_flat_cfg, make_k1_walk_rough_cfg),
+        (make_microduck_walk_flat_cfg, make_microduck_walk_rough_cfg),
     ],
 )
 def test_walk_rough_only_overrides_scene_spawn_range_and_render_spacing(make_flat_cfg, make_rough_cfg):
@@ -104,22 +125,24 @@ def test_walk_rough_only_overrides_scene_spawn_range_and_render_spacing(make_fla
 
 
 @pytest.mark.parametrize(
-    "make_cfg",
+    ("make_cfg", "camera_distance", "camera_lookat"),
     [
-        make_g129dof_walk_flat_cfg,
-        make_g129dof_walk_rough_cfg,
-        make_dex_evt_walk_flat_cfg,
-        make_dex_evt_walk_rough_cfg,
-        make_k1_walk_flat_cfg,
-        make_k1_walk_rough_cfg,
+        (make_g129dof_walk_flat_cfg, 6.0, None),
+        (make_g129dof_walk_rough_cfg, 6.0, None),
+        (make_dex_evt_walk_flat_cfg, 6.0, None),
+        (make_dex_evt_walk_rough_cfg, 6.0, None),
+        (make_k1_walk_flat_cfg, 6.0, None),
+        (make_k1_walk_rough_cfg, 6.0, None),
+        (make_microduck_walk_flat_cfg, 0.35, (0.0, 0.0, 0.12)),
+        (make_microduck_walk_rough_cfg, 0.35, (0.0, 0.0, 0.12)),
     ],
 )
-def test_walk_presets_use_shared_system_camera(make_cfg):
+def test_walk_presets_use_shared_system_camera(make_cfg, camera_distance, camera_lookat):
     scene = make_cfg().scene
 
     assert isinstance(scene, HumanoidWalkSceneCfg)
-    assert scene.system_camera.lookat is None
-    assert scene.system_camera.distance == pytest.approx(6.0)
+    assert scene.system_camera.lookat == camera_lookat
+    assert scene.system_camera.distance == pytest.approx(camera_distance)
     assert scene.system_camera.elevation == pytest.approx(-20.0)
     assert scene.system_camera.azimuth == pytest.approx(180.0)
 

--- a/motrix_envs/tests/test_robot_cfg.py
+++ b/motrix_envs/tests/test_robot_cfg.py
@@ -27,6 +27,7 @@ from motrix_envs.robot import (
     BoosterK1,
     DexEvt,
     HumanoidRobotCfg,
+    Microduck,
     QuadrupedLegCfg,
     QuadrupedRobotCfg,
     UnitreeG129Dof,
@@ -36,6 +37,7 @@ from motrix_envs.robot import (
 from motrix_envs.robot.anymal import ANYMAL_C_ASSET_DIR
 from motrix_envs.robot.booster import BOOSTER_K1_ASSET_DIR
 from motrix_envs.robot.dex_evt import DEX_EVT_ASSET_DIR
+from motrix_envs.robot.microduck import MICRODUCK_ASSET_DIR
 from motrix_envs.robot.unitree import UNITREE_G1_ASSET_DIR, UNITREE_GO1_ASSET_DIR, UNITREE_GO2_ASSET_DIR
 
 
@@ -69,6 +71,11 @@ class AnymalCSceneObjsCfg(SceneObjsCfg):
     robot: AnymalC = AnymalC()
 
 
+@configclass
+class MicroduckSceneObjsCfg(SceneObjsCfg):
+    robot: Microduck = Microduck()
+
+
 def test_builtin_robot_configs_are_registered():
     expected_types = {
         "anymal_c": AnymalC,
@@ -77,6 +84,7 @@ def test_builtin_robot_configs_are_registered():
         "go1": UnitreeGo1Robot,
         "go2": UnitreeGo2Robot,
         "k1": BoosterK1,
+        "microduck": Microduck,
     }
 
     assert set(expected_types).issubset(registry.list_registered_robots())
@@ -91,11 +99,12 @@ def test_builtin_robot_configs_use_robot_only_files():
     go1 = UnitreeGo1Robot()
     go2 = UnitreeGo2Robot()
     dex_evt = DexEvt()
+    microduck = Microduck()
 
-    assert all(isinstance(robot, RobotCfg) for robot in (anymal_c, k1, g1, go1, go2, dex_evt))
+    assert all(isinstance(robot, RobotCfg) for robot in (anymal_c, k1, g1, go1, go2, dex_evt, microduck))
     assert isinstance(anymal_c, QuadrupedRobotCfg)
     assert isinstance(anymal_c.model, MjcfFileCfg)
-    assert all(isinstance(robot, HumanoidRobotCfg) for robot in (k1, g1, dex_evt))
+    assert all(isinstance(robot, HumanoidRobotCfg) for robot in (k1, g1, dex_evt, microduck))
     assert isinstance(k1.model, MjcfFileCfg)
     assert isinstance(g1.model, MjcfFileCfg)
     assert isinstance(go1, QuadrupedRobotCfg)
@@ -109,6 +118,9 @@ def test_builtin_robot_configs_use_robot_only_files():
     assert Path(go1.model.file).parent == UNITREE_GO1_ASSET_DIR
     assert Path(go2.model.file).parent == UNITREE_GO2_ASSET_DIR
     assert Path(dex_evt.model.file).parent == DEX_EVT_ASSET_DIR
+    assert Path(microduck.model.file).parent == MICRODUCK_ASSET_DIR
+    assert Path(microduck.model.file).name == "microduck.xml"
+    assert not Path(microduck.model.file).name.startswith("scene_")
     assert Path(k1.model.file).name == "k1_22dof.xml"
     assert Path(g1.model.file).name == "g1_29dof.xml"
     assert Path(go1.model.file).name == "go1_position_actuator.xml"
@@ -129,6 +141,7 @@ def test_builtin_robot_configs_use_robot_only_files():
         (UnitreeG129Dof(), ("left_ankle_roll_link", "right_ankle_roll_link")),
         (DexEvt(), ("ankle_roll_l_link", "ankle_roll_r_link")),
         (BoosterK1(), ("left_foot_link", "right_foot_link")),
+        (Microduck(), ("ankle_left", "ankle_right")),
     ],
 )
 def test_builtin_humanoids_expose_foot_link_semantics(robot, foot_link_names):
@@ -335,6 +348,30 @@ def test_builtin_go2_asset_contains_all_referenced_meshes():
     root = ET.parse(UNITREE_GO2_ASSET_DIR / "go2_mjx.xml").getroot()
     referenced_meshes = {mesh.get("file") for mesh in root.findall("./asset/mesh")}
     packaged_meshes = {f"assets/{path.name}" for path in (UNITREE_GO2_ASSET_DIR / "assets").iterdir() if path.is_file()}
+
+    assert referenced_meshes == packaged_meshes
+
+
+def test_builtin_microduck_robot_builds_model():
+    model = build_scene_model(SceneCfg(objs=MicroduckSceneObjsCfg()))
+
+    assert model.body_names == ["trunk_base"]
+    assert model.get_body("trunk_base").floatingbase is not None
+    assert model.num_actuators == 14
+    assert "left_hip_yaw" in model.joint_names
+    assert "right_ankle" in model.joint_names
+    assert model.get_site("left_foot").parent_link.name == "ankle_left"
+    assert model.get_site("right_foot").parent_link.name == "ankle_right"
+    assert all(actuator.ctrl_range is not None for actuator in model.actuators)
+    assert all(actuator.force_range is not None for actuator in model.actuators)
+    assert [actuator.target_name for actuator in model.actuators] == Microduck().key_pose.joint_names
+    assert len(Microduck().key_pose.poses["default"]) == model.num_actuators
+
+
+def test_builtin_microduck_asset_contains_only_referenced_meshes():
+    root = ET.parse(MICRODUCK_ASSET_DIR / "microduck.xml").getroot()
+    referenced_meshes = {mesh.get("file") for mesh in root.findall("./asset/mesh")}
+    packaged_meshes = {path.name for path in (MICRODUCK_ASSET_DIR / "assets").iterdir() if path.is_file()}
 
     assert referenced_meshes == packaged_meshes
 


### PR DESCRIPTION
## Summary

- Port the Pollen Robotics Microduck 14-DoF biped MJCF and meshes from [microduck_rl](https://github.com/pollen-robotics/microduck_rl) (Apache-2.0 code, CC BY-SA-NC meshes), with STAND/SIT/FOLD key poses and a `trunk_collision` capsule on `trunk_base` for fall termination (sole geoms must touch the ground, so they can't be used for termination)
- Register robotcfg `microduck` (`motrix_envs/robot/microduck.py`) and `microduck-walk-flat` / `microduck-walk-rough` presets on the shared `HumanoidVelocityTrackingEnv`, with scale-tuned initial hyperparameters for the ~25 cm biped:
  - gait: `period=0.5`, `swing_height=0.04` (legs are ~8 cm; default 0.09 is too large)
  - commands: `vel_limit` restates the shared default (`lin_vel ±1.0 m/s`, `ang_vel ±1.0 rad/s`)
  - pose weights: low on legs, 50.0 on the 4 neck/head joints (keeps the head stable while walking, same treatment as G1 arms)
- Fix the shared foot-orientation penalty to measure against the **default-pose** foot gravity, so robots whose ankle frames aren't world-aligned (onshape-to-robot exports like Microduck) are no longer rewarded for tilting their soles
- Add task configs (`configs/task/microduck-walk-{flat,rough}/motrix.fastsac.yaml`), posters, bilingual env/robot docs, and test coverage

Does not modify `HumanoidVelocityTrackingEnv` otherwise; no Microduck-specific reward terms or observations.

Closes #17

## Verification

```bash
uv run scripts/view.py env=microduck-walk-flat        # renders, STAND pose soles on ground
uv run scripts/view.py env=microduck-walk-rough       # rough variant loads
uv run scripts/train.py task=microduck-walk-flat/motrix.fastsac
uv run pytest motrix_envs/tests
```
