### PR TITLE
docs: rework README with quickstart, architecture diagram and task showcase

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,4 @@
 *.npz filter=lfs diff=lfs merge=lfs -text
 docs/source/_static/data/performance/*.json filter=lfs diff=lfs merge=lfs -text
 docs/source/_static/images/performance/*.svg filter=lfs diff=lfs merge=lfs -text
+*.gif filter=lfs diff=lfs merge=lfs -text

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ MotrixLab 是构建在 MotrixSim 仿真后端之上的强化学习框架，提�
 
 ## Workspace 结构
 
-项目使用 UV workspace，包含十个 package：
+项目使用 UV workspace，包含九个 package：
 
 - `motrix_env_core`：backend 无关的环境框架（不依赖任何 simulator）
 - `motrix_env_motrixsim`：MotrixSim 仿真后端（SimBackend、scene compiler、renderer、torch frontend）
@@ -96,7 +96,7 @@ Python 方法，由 manager 运行时契约定义（`wiki/design/manager/runtime
 
 ### 版本与依赖一致性
 
-- 所有 workspace package（见上文 Workspace 结构，共十个）的 `pyproject.toml` 中 `version` 字段必须保持一致。
+- 所有 workspace package（见上文 Workspace 结构，共九个）的 `pyproject.toml` 中 `version` 字段必须保持一致。
 - MotrixSim 相关依赖版本必须在使用该依赖的 workspace package 之间保持一致。
 - 关键第三方依赖使用精确版本锁定（`===`）；新增或升级依赖时同步更新 `uv.lock`。
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ uv sync --all-packages --extra skrl-jax   # Linux only
 uv sync --all-packages --extra rslrl
 ```
 
-The workspace contains ten packages. Package-local changes should use the
+The workspace contains nine packages. Package-local changes should use the
 smallest required extra; changes involving the simulator, built-in assets, or
 training integrations should be tested with the corresponding package and
 extra enabled.
@@ -267,6 +267,6 @@ fork](https://docs.github.com/en/pull-requests/how-tos/create-pull-requests/crea
 and [secure use of GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions).
 
 All source files should retain the Apache-2.0 SPDX header used by this
-repository. Keep the ten workspace package versions synchronized when making a
+repository. Keep the nine workspace package versions synchronized when making a
 release, and update `THIRD_PARTY_NOTICES.md` whenever a dependency or bundled
 asset changes.

--- a/README.md
+++ b/README.md
@@ -1,154 +1,173 @@
 **Language**: [English](README.md) | [简体中文](README.zh-CN.md)
 
+<div align="center">
+
 # MotrixLab
 
-![GitHub License](https://img.shields.io/github/license/Motphys/MotrixLab)
+[![GitHub License](https://img.shields.io/github/license/Motphys/MotrixLab)](LICENSE)
 ![Python Version](https://img.shields.io/badge/python-3.10-blue)
+[![Release](https://img.shields.io/github/v/release/Motphys/MotrixLab?include_prereleases)](https://github.com/Motphys/MotrixLab/releases)
+[![Docs](https://img.shields.io/badge/docs-readthedocs-blue)](https://motrixlab.readthedocs.io)
 
-`MotrixLab` is a reinforcement learning framework based on the [MotrixSim](https://github.com/Motphys/motrixsim-docs) simulation engine, designed specifically for robot simulation and training. This project provides a complete reinforcement learning development platform that integrates multiple simulation environments and training frameworks.
+**Train robot policies in simulation, then deploy them to real hardware.**
 
-## Project Overview
+<img src="docs/source/_static/images/microduck-walk.gif" alt="Microduck robots walking in MotrixRender after training with MotrixLab" width="720">
 
-The project is divided into ten workspace packages:
+_Microduck locomotion policies trained with MotrixLab, rendered in MotrixRender — [watch the HD video](https://github.com/user-attachments/assets/4bcf3122-f135-44cb-a966-d2d8e84479da)._
 
-- **motrix_deploy** (`motrix-deploy`): Framework-independent artifact, backend, policy, control-loop, registry, and CLI
-- **motrix_deploy_mujoco** (`motrix-deploy-mujoco`): MuJoCo deployment backend plugin
-- **motrix_deploy_unitree** (`motrix-deploy-unitree`): Unitree SDK2 DDS hardware backend plugin
-- **motrix_deploy_tasks** (`motrix-deploy-tasks`): Concrete versioned deployment tasks and executable bootstrap
-- **motrix_env_core** (`motrix-env-core`): Environment base classes, configuration, registry, scene construction, NumPy runtime, and rendering. It contains no built-in tasks or robot assets
-- **motrix_env_motrixsim** (`motrix-env-motrixsim`): Live MotrixSim backend, renderer, and torch frontend
-- **motrix_env_mujoco** (`motrix-env-mujoco`): Compile-only MuJoCo scene backend
-- **motrix_envs** (`motrix-envs`): Built-in environments, models, data, and environment-to-deployment-profile compilers
-- **motrix_rl** (`motrix-rl`): RL-framework integration built against `motrix-env-core`, with SKRL, RSLRL, and FastSAC support
+**📖 Documentation**: [简体中文](https://motrixlab.readthedocs.io/zh-cn/stable/) | [English](https://motrixlab.readthedocs.io/en/stable/)
 
-> Documentation: https://motrixlab.readthedocs.io
+</div>
+
+## Contents
+
+- [What is MotrixLab?](#what-is-motrixlab)
+- [Key Features](#key-features)
+- [Quick Start](#-quick-start)
+- [Task Environments](#-task-environments)
+- [Built-in Robot Models](#-built-in-robot-models)
+- [What's Inside](#-whats-inside)
+- [Contributing](#-contributing)
+- [Contact](#-contact)
+
+## What is MotrixLab?
+
+**MotrixLab** is an open-source reinforcement learning framework for robot training, built on the high-performance [MotrixSim](https://github.com/Motphys/motrixsim-docs) physics engine. Define an environment once, train it with thousands of parallel environment instances using SKRL, RSL-RL, or the built-in FastSAC, and deploy the resulting policy to MuJoCo or Unitree hardware — all through a single command-line interface.
+
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/source/_static/images/architecture-dark.svg">
+    <img src="docs/source/_static/images/architecture-light.svg" alt="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments, then deploy the same policy artifact to MuJoCo or Unitree hardware" width="720">
+  </picture>
+</div>
 
 ## Key Features
 
 - **Unified Interface**: Provides a concise and unified reinforcement learning training and evaluation interface
 - **Multi-framework Support**: Supports SKRL (JAX/PyTorch), RSLRL (PyTorch), and the built-in FastSAC implementation
 - **Rich Environments**: Includes various robot simulation environments such as basic control, locomotion, and manipulation tasks
-- **High-performance Simulation**: Built on MotrixSim's high-performance physics simulation engine
+- **Sim-to-Real Deployment**: The same policy code deploys via the deploy CLI — Sim2Sim to MuJoCo, Sim2Real to real hardware
+- **High-precision, High-performance Simulation**: Built on [MotrixSim](https://motrixsim.readthedocs.io/), a high-precision, high-performance physics engine
 - **Visual Training**: Supports real-time rendering and training process visualization
 
 ## 🚀 Quick Start
 
-> The following examples use the Python project management tool: [UV](https://docs.astral.sh/uv/)
->
-> Before starting, please [install](https://docs.astral.sh/uv/getting-started/installation/) this tool.
+### Prerequisites
 
-### Clone Repository
+| Requirement | Notes |
+| --- | --- |
+| Python **3.10.x** | The workspace pins `==3.10.*` |
+| [uv](https://docs.astral.sh/uv/) | Python project and dependency manager — [installation guide](https://docs.astral.sh/uv/getting-started/installation/) |
+| [Git LFS](https://git-lfs.com) | Robot meshes, motion data, and videos are tracked by LFS |
+| OS | Linux x86_64 or Windows x86_64; the JAX training backend is Linux-only |
+
+### 1. Clone the repository
 
 ```bash
 git clone https://github.com/Motphys/MotrixLab
-
 cd MotrixLab
-
 git lfs pull
 ```
 
-### Install Dependencies
-
-Install all dependencies:
+### 2. Install dependencies
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+uv sync --all-packages
 ```
 
-For an external project that only needs the environment framework, install `motrix-env-core`. Install
-`motrix-envs` when the built-in MotrixLab tasks and assets are also required.
+This installs all workspace packages together with **PyTorch**, the default training backend used by the built-in FastSAC. Third-party frameworks such as SKRL and RSLRL are optional extras.
 
-SKRL framework supports JAX(Flax) or PyTorch as training backends. You can also choose to install only one training backend based on your hardware environment:
-
-Install JAX as training backend (Linux only):
+### 3. Train your first policy
 
 ```bash
-uv sync --all-packages --extra skrl-jax
+uv run scripts/train.py task=microduck-walk-flat/motrix.fastsac play=true
 ```
 
-Install PyTorch as training backend:
+While training, the built-in dashboard shows live run progress, episode statistics, throughput, rewards, and system health:
+
+<p align="center">
+  <img src="docs/source/_static/images/train-console.png" alt="MotrixLab training dashboard for the microduck-walk-flat fastsac task" width="720">
+</p>
+
+Training runs thousands of parallel environment instances; when it finishes, the trained policy is loaded and played in the viewer automatically. Checkpoints and TensorBoard logs are saved under `runs/microduck-walk-flat/`; watch the curves with:
 
 ```bash
-uv sync --all-packages --extra skrl-torch
+uv run tensorboard --logdir runs/microduck-walk-flat
 ```
 
-Install RSLRL framework (PyTorch backend only):
+Training finishes in minutes: mean return and episode length typically converge after about 4,000 iterations:
+
+<p align="center">
+  <img src="docs/source/_static/images/microduck-training-curves.png" alt="TensorBoard curves of a microduck-walk-flat training run: mean return and episode length converge after about 4,000 iterations" width="720">
+</p>
+
+### 4. Replay the trained policy
+
+Replay the latest trained policy without retraining (for example, after stopping training early with Ctrl+C):
 
 ```bash
-uv sync --all-packages --extra rslrl
+uv run scripts/play.py env=microduck-walk-flat
 ```
 
-### Development Checks
+A trained microduck policy replayed in the viewer:
 
-[`dprint-py`](https://pypi.org/project/dprint-py/) is included in the development dependencies. Install
-[`prek`](https://github.com/j178/prek), enable the Git pre-commit hook, and run all configured checks:
+https://github.com/user-attachments/assets/4bcf3122-f135-44cb-a966-d2d8e84479da
+
+## 🌍 Task Environments
+
+MotrixLab ships 50+ built-in simulation environments spanning basic control, quadruped and humanoid locomotion, whole-body motion tracking, and manipulation. The main categories:
+
+| Preview | Category | Example environments |
+| --- | --- | --- |
+| <img src="docs/source/_static/images/poster/go2-walk-rough.jpg" alt="go2-walk-rough" width="240"> | Quadruped velocity tracking | `go2-walk-flat` · `go2-walk-rough` · `go1-walk-rough` · `anymalc-walk-flat` |
+| <img src="docs/source/_static/images/poster/g1-walk-flat.jpg" alt="g1-walk-flat" width="240"> | Humanoid velocity tracking | `g1-walk-flat` · `k1-walk-rough` · `dex-evt-walk-flat` · `microduck-walk-flat` |
+| <img src="docs/source/_static/images/poster/g1-wbt-dance.jpg" alt="g1-wbt-dance" width="240"> | Whole-body tracking (WBT) | `g1-wbt-dance` · `k1-wbt-freekick` · `g1-29dof-wbt-largebox` |
 
 ```bash
-uv tool install prek==0.5.2
-prek install
-prek run --all-files
+uv run scripts/view.py env=go2-walk-rough
 ```
 
-Run dprint directly through uv when needed:
+See the [full environment gallery](https://motrixlab.readthedocs.io/en/latest/user_guide/envs/index.html) for all registered environments and their supported training algorithms.
+
+## 🤖 Built-in Robot Models
+
+Seven reusable robot models are registered out of the box and can be combined into any scene or task:
+
+| Screenshot | Registry name | Type | DoF |
+| --- | --- | --- | --- |
+| <img src="docs/source/_static/images/robots/anymal_c.png" alt="anymal_c" width="180"> | `anymal_c` | Quadruped | 12 |
+| <img src="docs/source/_static/images/robots/dex-evt.png" alt="dex-evt" width="180"> | `dex-evt` | Humanoid | 23 |
+| <img src="docs/source/_static/images/robots/g1-29dof.png" alt="g1-29dof" width="180"> | `g1-29dof` | Humanoid | 29 |
+| <img src="docs/source/_static/images/robots/go1.png" alt="go1" width="180"> | `go1` | Quadruped | 12 |
+| <img src="docs/source/_static/images/robots/go2.png" alt="go2" width="180"> | `go2` | Quadruped | 12 |
+| <img src="docs/source/_static/images/robots/k1.png" alt="k1" width="180"> | `k1` | Humanoid | 22 |
+| <img src="docs/source/_static/images/robots/microduck.png" alt="microduck" width="180"> | `microduck` | Humanoid | 14 |
 
 ```bash
-uv run dprint fmt
+uv run scripts/view.py robot=go2
 ```
 
-## 🎯 Usage Guide
+See [Supported Robots](https://motrixlab.readthedocs.io/en/latest/user_guide/robots.html) for configuration details and how to add your own model.
 
-### Environment Visualization
+## 🏗️ What's Inside
 
-View environments without executing training:
+MotrixLab is a [uv](https://docs.astral.sh/uv/) workspace of nine packages:
 
-```bash
-uv run scripts/view.py env=cartpole
-```
+| Package | PyPI name | Description |
+| --- | --- | --- |
+| **motrix_deploy** | `motrix-deploy` | Framework-independent artifact, backend, policy, control-loop, registry, and CLI |
+| **motrix_deploy_mujoco** | `motrix-deploy-mujoco` | MuJoCo deployment backend plugin |
+| **motrix_deploy_unitree** | `motrix-deploy-unitree` | Unitree SDK2 DDS hardware backend plugin |
+| **motrix_deploy_tasks** | `motrix-deploy-tasks` | Concrete versioned deployment tasks and executable bootstrap |
+| **motrix_env_core** | `motrix-env-core` | Environment base classes, configuration, registry, scene construction, NumPy runtime, and rendering. It contains no built-in tasks or robot assets |
+| **motrix_env_motrixsim** | `motrix-env-motrixsim` | Live MotrixSim backend, renderer, and torch frontend |
+| **motrix_env_mujoco** | `motrix-env-mujoco` | Compile-only MuJoCo scene backend |
+| **motrix_envs** | `motrix-envs` | Built-in environments, models, data, and environment-to-deployment-profile compilers |
+| **motrix_rl** | `motrix-rl` | RL-framework integration built against `motrix-env-core`, with SKRL, RSLRL, and FastSAC support |
 
-View a built-in robot in a static standard scene:
+## 🤝 Contributing
 
-```bash
-uv run scripts/view.py robot=g1-29dof
-```
-
-Available built-in robot names are `dex-evt`, `g1-29dof`, `go1`, `go2`, and `k1`.
-
-### Model Training
-
-Train the default Cartpole SKRL task:
-
-```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
-```
-
-Train with RSLRL framework:
-
-```bash
-uv run scripts/train.py task=cartpole/rslrl.ppo
-```
-
-Override runtime settings and algorithm parameters directly through Hydra:
-
-```bash
-uv run scripts/train.py task=cartpole/skrl.ppo num_envs=64 algo.agent.learning_rate=1e-3
-uv run scripts/train.py task=cartpole/skrl.ppo logging.interval=20 checkpoint.interval=100
-```
-
-Training results are saved in the `runs/{env-name}/` directory.
-
-View training data through TensorBoard:
-
-```bash
-uv run tensorboard --logdir runs/{env-name}
-```
-
-### Model Inference
-
-```bash
-uv run scripts/play.py env=cartpole
-```
-
-For more usage methods, please refer to the [User Documentation](https://motrixlab.readthedocs.io)
+Contributions are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md) for the development environment setup, branch and commit conventions, and the configured checks (`prek`, `ruff`, `dprint`, `mypy`).
 
 ## 📬 Contact
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,154 +1,173 @@
 **语言**: [English](README.md) | [简体中文](README.zh-CN.md)
 
+<div align="center">
+
 # MotrixLab
 
-![GitHub License](https://img.shields.io/github/license/Motphys/MotrixLab)
+[![GitHub License](https://img.shields.io/github/license/Motphys/MotrixLab)](LICENSE)
 ![Python Version](https://img.shields.io/badge/python-3.10-blue)
+[![Release](https://img.shields.io/github/v/release/Motphys/MotrixLab?include_prereleases)](https://github.com/Motphys/MotrixLab/releases)
+[![Docs](https://img.shields.io/badge/docs-readthedocs-blue)](https://motrixlab.readthedocs.io)
 
-`MotrixLab` 是一个基于 [MotrixSim](https://github.com/Motphys/motrixsim-docs) 仿真引擎的强化学习框架，专为机器人仿真和训练设计。该项目提供了一个完整的强化学习开发平台，集成了多种仿真环境和训练框架。
+**在仿真中训练机器人策略，并部署到真实硬件。**
 
-## 项目概述
+<img src="docs/source/_static/images/microduck-walk.gif" alt="使用 MotrixLab 训练的 microduck 机器人在 MotrixRender 中行走" width="720">
 
-该项目由十个 workspace package 组成：
+_使用 MotrixLab 训练的 microduck 行走策略，由 MotrixRender 实时渲染 — [观看高清视频](https://github.com/user-attachments/assets/4bcf3122-f135-44cb-a966-d2d8e84479da)。_
 
-- **motrix_deploy**（`motrix-deploy`）：独立于训练框架的 artifact、backend、policy、控制循环、registry 与 CLI
-- **motrix_deploy_mujoco**（`motrix-deploy-mujoco`）：MuJoCo 部署 backend plugin
-- **motrix_deploy_unitree**（`motrix-deploy-unitree`）：Unitree SDK2 DDS 硬件 backend plugin
-- **motrix_deploy_tasks**（`motrix-deploy-tasks`）：具体的带版本部署任务实现与可执行入口 bootstrap
-- **motrix_env_core**（`motrix-env-core`）：环境基类、配置、registry、场景构建、NumPy runtime 与渲染能力，不包含任何内置任务和机器人资产
-- **motrix_env_motrixsim**（`motrix-env-motrixsim`）：MotrixSim 实时仿真 backend、renderer 与 torch frontend
-- **motrix_env_mujoco**（`motrix-env-mujoco`）：仅负责编译场景的 MuJoCo backend
-- **motrix_envs**（`motrix-envs`）：内置环境、模型、数据及环境到部署 profile 的编译实现
-- **motrix_rl**（`motrix-rl`）：基于 `motrix-env-core` 的 RL 框架集成，支持 SKRL、RSLRL 和 FastSAC
+**📖 用户文档**: [简体中文](https://motrixlab.readthedocs.io/zh-cn/stable/) | [English](https://motrixlab.readthedocs.io/en/stable/)
 
-> 文档地址：https://motrixlab.readthedocs.io
+</div>
+
+## 目录
+
+- [MotrixLab 是什么？](#motrixlab-是什么)
+- [主要特性](#主要特性)
+- [快速开始](#-快速开始)
+- [任务环境](#-任务环境)
+- [内置机器人模型](#-内置机器人模型)
+- [项目组成](#-项目组成)
+- [参与贡献](#-参与贡献)
+- [联系方式](#-联系方式)
+
+## MotrixLab 是什么？
+
+**MotrixLab** 是一个开源的机器人强化学习训练框架，构建于高性能的 [MotrixSim](https://github.com/Motphys/motrixsim-docs) 物理引擎之上。环境只需定义一次，即可通过 SKRL、RSLRL 或内置的 FastSAC 使用数千个并行环境实例进行训练，训练得到的策略可部署到 MuJoCo 或 Unitree 硬件 —— 全程只需一个命令行接口。
+
+<div align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="docs/source/_static/images/architecture-dark.svg">
+    <img src="docs/source/_static/images/architecture-light.svg" alt="MotrixLab 架构：环境只需定义一次，即可用 SKRL、RSL-RL 或 FastSAC 在数千个并行 MotrixSim 环境上训练，同一策略产物可部署到 MuJoCo 或 Unitree 硬件" width="720">
+  </picture>
+</div>
 
 ## 主要特性
 
 - **统一接口**: 提供简洁统一的强化学习训练和评估接口
 - **多框架支持**: 支持 SKRL（JAX/PyTorch）、RSLRL（PyTorch）和内置 FastSAC 实现
 - **丰富环境**: 包含基础控制、运动、操作等多种机器人仿真环境
-- **高性能仿真**: 基于 MotrixSim 的高性能物理仿真引擎
+- **Sim-to-Real 部署**: 同一套策略代码，通过部署 CLI Sim2Sim 到 MuJoCo 仿真、Sim2Real 到真实硬件
+- **高精度高性能仿真**: 基于 [MotrixSim](https://motrixsim.readthedocs.io/) 高精度、高性能物理仿真引擎
 - **可视化训练**: 支持实时渲染和训练过程可视化
 
 ## 🚀 快速开始
 
-> 以下示例使用了 Python 项目管理工具：[UV](https://docs.astral.sh/uv/)
->
-> 在开始之前，请先[安装](https://docs.astral.sh/uv/getting-started/installation/)该工具。
+### 前置条件
 
-### 克隆仓库
+| 要求 | 说明 |
+| --- | --- |
+| Python **3.10.x** | workspace 锁定 `==3.10.*` |
+| [uv](https://docs.astral.sh/uv/) | Python 项目与依赖管理工具 — [安装指南](https://docs.astral.sh/uv/getting-started/installation/) |
+| [Git LFS](https://git-lfs.com) | 机器人网格、运动数据与视频由 LFS 管理 |
+| 操作系统 | Linux x86_64 或 Windows x86_64；JAX 训练后端仅支持 Linux |
+
+### 1. 克隆仓库
 
 ```bash
 git clone https://github.com/Motphys/MotrixLab
-
 cd MotrixLab
-
 git lfs pull
 ```
 
-### 安装依赖
-
-安装全部依赖：
+### 2. 安装依赖
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+uv sync --all-packages
 ```
 
-外部项目如果只需要环境 framework，可单独安装 `motrix-env-core`；需要 MotrixLab 内置任务和资产时再安装
-`motrix-envs`。
+该命令会安装全部 workspace package，以及内置 FastSAC 所需的默认训练后端 **PyTorch**。SKRL、RSLRL 等第三方训练框架为可选 extras。
 
-SKRL 框架支持 JAX(Flax)或 PyTorch 作为训练后端，您也可以根据自己的设备环境，选择只安装其中一种训练后端：
-
-安装 JAX 作为训练后端（仅支持 Linux 平台）：
+### 3. 训练第一个策略
 
 ```bash
-uv sync --all-packages --extra skrl-jax
+uv run scripts/train.py task=microduck-walk-flat/motrix.fastsac play=true
 ```
 
-安装 PyTorch 作为训练后端：
+训练过程中，内置面板会实时显示运行进度、回合统计、吞吐、奖励与系统健康状态：
+
+<p align="center">
+  <img src="docs/source/_static/images/train-console.png" alt="microduck-walk-flat motrix.fastsac 任务的 MotrixLab 训练面板" width="720">
+</p>
+
+训练会启动数千个并行环境实例；训练结束后会自动加载策略并在查看器中回放。checkpoint 与 TensorBoard 日志保存在 `runs/microduck-walk-flat/` 目录下，通过以下命令查看训练曲线：
 
 ```bash
-uv sync --all-packages --extra skrl-torch
+uv run tensorboard --logdir runs/microduck-walk-flat
 ```
 
-安装 RSLRL 框架（仅支持 PyTorch 后端）：
+microduck 的训练数分钟内即可完成：平均回报与回合长度通常在约 4,000 次迭代后收敛：
+
+<p align="center">
+  <img src="docs/source/_static/images/microduck-training-curves.png" alt="microduck-walk-flat 训练的 TensorBoard 曲线：平均回报与回合长度在约 4,000 次迭代后收敛" width="720">
+</p>
+
+### 4. 回放训练好的策略
+
+无需重新训练即可回放最近一次训练得到的策略（例如提前 Ctrl+C 中断训练之后）：
 
 ```bash
-uv sync --all-packages --extra rslrl
+uv run scripts/play.py env=microduck-walk-flat
 ```
 
-### 开发检查
+训练好的 microduck 策略在查看器中的回放效果：
 
-开发依赖已包含 [`dprint-py`](https://pypi.org/project/dprint-py/)。安装
-[`prek`](https://github.com/j178/prek)、启用 Git pre-commit hook，并运行所有已配置的检查：
+https://github.com/user-attachments/assets/4bcf3122-f135-44cb-a966-d2d8e84479da
+
+## 🌍 任务环境
+
+MotrixLab 内置 50+ 个仿真环境，覆盖基础控制、四足、人形、全身动作跟踪、操作等类别。主要类别如下：
+
+| 预览图 | 类别 | 示例环境 |
+| --- | --- | --- |
+| <img src="docs/source/_static/images/poster/go2-walk-rough.jpg" alt="go2-walk-rough" width="240"> | 四足速度跟踪 | `go2-walk-flat` · `go2-walk-rough` · `go1-walk-rough` · `anymalc-walk-flat` |
+| <img src="docs/source/_static/images/poster/g1-walk-flat.jpg" alt="g1-walk-flat" width="240"> | 人形速度跟踪 | `g1-walk-flat` · `k1-walk-rough` · `dex-evt-walk-flat` · `microduck-walk-flat` |
+| <img src="docs/source/_static/images/poster/g1-wbt-dance.jpg" alt="g1-wbt-dance" width="240"> | 全身动作跟踪（WBT） | `g1-wbt-dance` · `k1-wbt-freekick` · `g1-29dof-wbt-largebox` |
 
 ```bash
-uv tool install prek==0.5.2
-prek install
-prek run --all-files
+uv run scripts/view.py env=go2-walk-rough
 ```
 
-需要单独运行 dprint 时，通过 uv 执行：
+完整环境列表与各环境支持的训练算法见[环境总览](https://motrixlab.readthedocs.io/zh-cn/latest/user_guide/envs/index.html)。
+
+## 🤖 内置机器人模型
+
+通过 robot registry 内置 7 个可复用机器人模型，可与任意场景和任务组合：
+
+| 截图 | Registry 名称 | 类型 | 自由度 |
+| --- | --- | --- | --- |
+| <img src="docs/source/_static/images/robots/anymal_c.png" alt="anymal_c" width="180"> | `anymal_c` | 四足机器人 | 12 |
+| <img src="docs/source/_static/images/robots/dex-evt.png" alt="dex-evt" width="180"> | `dex-evt` | 人形机器人 | 23 |
+| <img src="docs/source/_static/images/robots/g1-29dof.png" alt="g1-29dof" width="180"> | `g1-29dof` | 人形机器人 | 29 |
+| <img src="docs/source/_static/images/robots/go1.png" alt="go1" width="180"> | `go1` | 四足机器人 | 12 |
+| <img src="docs/source/_static/images/robots/go2.png" alt="go2" width="180"> | `go2` | 四足机器人 | 12 |
+| <img src="docs/source/_static/images/robots/k1.png" alt="k1" width="180"> | `k1` | 人形机器人 | 22 |
+| <img src="docs/source/_static/images/robots/microduck.png" alt="microduck" width="180"> | `microduck` | 人形机器人 | 14 |
 
 ```bash
-uv run dprint fmt
+uv run scripts/view.py robot=go2
 ```
 
-## 🎯 使用指南
+机器人配置细节与自定义新模型的方法见[支持的机器人](https://motrixlab.readthedocs.io/zh-cn/latest/user_guide/robots.html)。
 
-### 环境可视化
+## 🏗️ 项目组成
 
-查看环境而不执行训练：
+MotrixLab 是一个由九个 package 组成的 [uv](https://docs.astral.sh/uv/) workspace：
 
-```bash
-uv run scripts/view.py env=cartpole
-```
+| Package | PyPI 名称 | 说明 |
+| --- | --- | --- |
+| **motrix_deploy** | `motrix-deploy` | 独立于训练框架的 artifact、backend、policy、控制循环、registry 与 CLI |
+| **motrix_deploy_mujoco** | `motrix-deploy-mujoco` | MuJoCo 部署 backend plugin |
+| **motrix_deploy_unitree** | `motrix-deploy-unitree` | Unitree SDK2 DDS 硬件 backend plugin |
+| **motrix_deploy_tasks** | `motrix-deploy-tasks` | 具体的带版本部署任务实现与可执行入口 bootstrap |
+| **motrix_env_core** | `motrix-env-core` | 环境基类、配置、registry、场景构建、NumPy runtime 与渲染能力，不包含任何内置任务和机器人资产 |
+| **motrix_env_motrixsim** | `motrix-env-motrixsim` | MotrixSim 实时仿真 backend、renderer 与 torch frontend |
+| **motrix_env_mujoco** | `motrix-env-mujoco` | 仅负责编译场景的 MuJoCo backend |
+| **motrix_envs** | `motrix-envs` | 内置环境、模型、数据及环境到部署 profile 的编译实现 |
+| **motrix_rl** | `motrix-rl` | 基于 `motrix-env-core` 的 RL 框架集成，支持 SKRL、RSLRL 和 FastSAC |
 
-在静态标准场景中查看内置机器人：
+## 🤝 参与贡献
 
-```bash
-uv run scripts/view.py robot=g1-29dof
-```
-
-可用的内置机器人名称包括 `dex-evt`、`g1-29dof`、`go1`、`go2` 和 `k1`。
-
-### 训练模型
-
-使用默认的 Cartpole SKRL 任务训练：
-
-```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
-```
-
-使用 RSLRL 框架训练：
-
-```bash
-uv run scripts/train.py task=cartpole/rslrl.ppo
-```
-
-通过 Hydra 直接覆盖运行参数和算法参数：
-
-```bash
-uv run scripts/train.py task=cartpole/skrl.ppo num_envs=64 algo.agent.learning_rate=1e-3
-uv run scripts/train.py task=cartpole/skrl.ppo logging.interval=20 checkpoint.interval=100
-```
-
-训练结果会保存在 `runs/{env-name}/` 目录下。
-
-通过 TensorBoard 查看训练数据：
-
-```bash
-uv run tensorboard --logdir runs/{env-name}
-```
-
-### 模型推理
-
-```bash
-uv run scripts/play.py env=cartpole
-```
-
-更多使用方式请参考[用户文档](https://motrixlab.readthedocs.io)
+欢迎参与贡献！开发环境搭建、分支与提交规范、以及仓库配置的检查工具（`prek`、`ruff`、`dprint`、`mypy`）请参见 [CONTRIBUTING.md](CONTRIBUTING.md)。
 
 ## 📬 联系方式
 

--- a/docs/source/_static/images/architecture-dark.svg
+++ b/docs/source/_static/images/architecture-dark.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="500" viewBox="0 0 1160 500" role="img" aria-label="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments, then deploy the same policy artifact to MuJoCo or Unitree hardware, with more hardware backends planned. Built-in environments cover basic control, locomotion, manipulation and whole-body tracking.">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#818cf8"/>
+    </marker>
+  </defs>
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif; }
+    .mono { font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace; }
+    .stage   { font-size: 15px; font-weight: 700; letter-spacing: 2px; fill: #818cf8; }
+    .title   { font-size: 15.5px; font-weight: 700; fill: #e6edf3; }
+    .chip    { font-size: 15px; font-weight: 700; fill: #e6edf3; }
+    .body    { font-size: 13.5px; fill: #e6edf3; }
+    .sub     { font-size: 12px; fill: #9198a1; }
+    .tag     { font-size: 11.5px; font-weight: 600; }
+    .badge   { font-size: 12.5px; font-weight: 600; fill: #a5b4fc; }
+    .card    { fill: #161b22; stroke: #30363d; stroke-width: 1.2; }
+    .flow    { fill: none; stroke: #818cf8; stroke-width: 1.8; marker-end: url(#arrow); }
+    .flow-future { fill: none; stroke: #818cf8; stroke-width: 1.8; stroke-dasharray: 5 4; opacity: 0.7; marker-end: url(#arrow); }
+  </style>
+
+  <rect x="0" y="0" width="1160" height="500" rx="18" fill="#0d1117"/>
+
+  <!-- ============ top CLI bar ============ -->
+  <rect x="36" y="24" width="1088" height="40" rx="20" class="card"/>
+  <text x="580" y="49" text-anchor="middle" class="sans" font-size="13"><tspan font-weight="700" fill="#e6edf3">One CLI, end to end:&#160;&#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">train</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">play</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">view</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">export</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">deploy</tspan></text>
+
+  <!-- ============ stage headers ============ -->
+  <text x="168" y="104" text-anchor="middle" class="sans stage">DEFINE ONCE</text>
+  <text x="541" y="104" text-anchor="middle" class="sans stage">TRAIN FAST</text>
+  <text x="1008" y="104" text-anchor="middle" class="sans stage">DEPLOY ANYWHERE</text>
+
+  <!-- ============ stage 1: environment definition ============ -->
+  <rect x="36" y="130" width="264" height="158" rx="12" class="card"/>
+  <text x="168" y="160" text-anchor="middle" class="sans title">Environment definition</text>
+  <line x1="60" y1="174" x2="276" y2="174" stroke="#30363d" stroke-width="1"/>
+  <text x="64" y="198" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Observations &amp; actions</tspan></text>
+  <text x="64" y="224" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Rewards &amp; terminations</tspan></text>
+  <text x="64" y="250" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Scene, robot &amp; assets</tspan></text>
+  <text x="64" y="276" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">One shared config schema</tspan></text>
+
+  <text x="168" y="312" text-anchor="middle" class="sans" font-size="11" font-weight="600" letter-spacing="1.5" fill="#9198a1">BUILT-IN LIBRARY</text>
+  <rect x="36" y="320" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Basic control</text>
+  <rect x="172" y="320" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Locomotion</text>
+  <rect x="36" y="354" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Manipulation</text>
+  <rect x="172" y="354" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Whole-body tracking</text>
+
+  <!-- ============ stage 2: training frameworks ============ -->
+  <rect x="386" y="130" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="163" class="sans chip">SKRL</text>
+  <rect x="593" y="146" width="97" height="24" rx="12" fill="#202542" stroke="#3b4468" stroke-width="1"/>
+  <text x="641.5" y="162" text-anchor="middle" class="sans tag" fill="#a5b4fc">JAX &#183; PyTorch</text>
+
+  <rect x="386" y="200" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="233" class="sans chip">RSL-RL</text>
+  <rect x="629" y="216" width="61" height="24" rx="12" fill="#202542" stroke="#3b4468" stroke-width="1"/>
+  <text x="659.5" y="232" text-anchor="middle" class="sans tag" fill="#a5b4fc">PyTorch</text>
+
+  <rect x="386" y="270" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="303" class="sans chip">FastSAC</text>
+  <rect x="618" y="286" width="72" height="24" rx="12" fill="#5450d6"/>
+  <text x="654" y="302" text-anchor="middle" class="sans tag" fill="#fefefe">built-in &#9733;</text>
+
+  <rect x="386" y="352" width="310" height="46" rx="10" fill="none" stroke="#30363d" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="541" y="373" text-anchor="middle" class="sans" font-size="13" font-weight="600" fill="#e6edf3">Thousands of parallel environments</text>
+  <text x="541" y="392" text-anchor="middle" class="sans" font-size="13" fill="#9198a1">on <tspan fill="#818cf8" font-weight="700">MotrixSim</tspan></text>
+
+  <!-- ============ artifact pill ============ -->
+  <rect x="736" y="206" width="132" height="64" rx="32" fill="#202542" stroke="#818cf8" stroke-width="1.4"/>
+  <text x="802" y="234" text-anchor="middle" class="sans" font-size="13" font-weight="700" fill="#a5b4fc">policy artifact</text>
+  <text x="802" y="252" text-anchor="middle" class="mono" font-size="11" fill="#9198a1">.onnx / .pt</text>
+
+  <!-- ============ stage 3: deployment targets ============ -->
+  <rect x="892" y="144" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="168" class="sans chip">MuJoCo</text>
+  <text x="912" y="187" class="sans sub">simulation replay</text>
+  <rect x="1054" y="158" width="50" height="24" rx="12" fill="#102a45" stroke="#4493f8" stroke-width="1"/>
+  <text x="1079" y="174" text-anchor="middle" class="sans tag" font-size="11" fill="#4493f8">SIM</text>
+
+  <rect x="892" y="208" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="232" class="sans chip">Unitree</text>
+  <text x="912" y="251" class="sans sub">real hardware &#183; DDS</text>
+  <rect x="1054" y="222" width="50" height="24" rx="12" fill="#122d1f" stroke="#2ea043" stroke-width="1"/>
+  <text x="1079" y="238" text-anchor="middle" class="sans tag" font-size="11" fill="#3fb950">REAL</text>
+
+  <rect x="892" y="272" width="232" height="52" rx="10" fill="none" stroke="#30363d" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="1008" y="295" text-anchor="middle" class="sans" font-size="13.5" font-weight="700" fill="#9198a1">+ more hardware</text>
+  <text x="1008" y="313" text-anchor="middle" class="sans sub" font-size="11.5">on the roadmap</text>
+
+  <!-- ============ connectors ============ -->
+  <path class="flow" d="M 300 235 C 338 235 348 158 386 158"/>
+  <path class="flow" d="M 300 235 C 338 235 348 228 386 228"/>
+  <path class="flow" d="M 300 235 C 338 235 348 298 386 298"/>
+  <path class="flow" d="M 696 158 C 716 158 716 238 736 238"/>
+  <path class="flow" d="M 696 228 C 712 228 720 238 736 238"/>
+  <path class="flow" d="M 696 298 C 716 298 716 238 736 238"/>
+  <path class="flow" d="M 868 238 C 880 238 880 170 892 170"/>
+  <path class="flow" d="M 868 238 C 880 238 880 234 892 234"/>
+  <path class="flow-future" d="M 868 238 C 880 238 880 298 892 298"/>
+
+  <!-- ============ takeaway badges ============ -->
+  <rect x="49" y="424" width="238" height="38" rx="19" fill="#202542" stroke="#3b4468" stroke-width="1"/>
+  <text x="168" y="448" text-anchor="middle" class="sans badge">One definition, every framework</text>
+
+  <rect x="430" y="424" width="232" height="38" rx="19" fill="#202542" stroke="#3b4468" stroke-width="1"/>
+  <text x="546" y="448" text-anchor="middle" class="sans badge">Minutes to converge, not hours</text>
+
+  <rect x="892" y="424" width="232" height="38" rx="19" fill="#202542" stroke="#3b4468" stroke-width="1"/>
+  <text x="1008" y="448" text-anchor="middle" class="sans badge">From sim to real, one artifact</text>
+</svg>

--- a/docs/source/_static/images/architecture-light.svg
+++ b/docs/source/_static/images/architecture-light.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="500" viewBox="0 0 1160 500" role="img" aria-label="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments, then deploy the same policy artifact to MuJoCo or Unitree hardware, with more hardware backends planned. Built-in environments cover basic control, locomotion, manipulation and whole-body tracking.">
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#4f46e5"/>
+    </marker>
+  </defs>
+  <style>
+    .sans { font-family: -apple-system, "Segoe UI", "Helvetica Neue", Helvetica, Arial, sans-serif; }
+    .mono { font-family: ui-monospace, "SF Mono", "Cascadia Code", Menlo, Consolas, monospace; }
+    .stage   { font-size: 15px; font-weight: 700; letter-spacing: 2px; fill: #4f46e5; }
+    .title   { font-size: 15.5px; font-weight: 700; fill: #1f2328; }
+    .chip    { font-size: 15px; font-weight: 700; fill: #1f2328; }
+    .body    { font-size: 13.5px; fill: #1f2328; }
+    .sub     { font-size: 12px; fill: #57606a; }
+    .tag     { font-size: 11.5px; font-weight: 600; }
+    .badge   { font-size: 12.5px; font-weight: 600; fill: #4338ca; }
+    .card    { fill: #ffffff; stroke: #d0d7de; stroke-width: 1.2; }
+    .flow    { fill: none; stroke: #4f46e5; stroke-width: 1.8; marker-end: url(#arrow); }
+    .flow-future { fill: none; stroke: #4f46e5; stroke-width: 1.8; stroke-dasharray: 5 4; opacity: 0.7; marker-end: url(#arrow); }
+  </style>
+
+  <rect x="0" y="0" width="1160" height="500" rx="18" fill="#f6f8fa"/>
+
+  <!-- ============ top CLI bar ============ -->
+  <rect x="36" y="24" width="1088" height="40" rx="20" class="card"/>
+  <text x="580" y="49" text-anchor="middle" class="sans" font-size="13"><tspan font-weight="700" fill="#1f2328">One CLI, end to end:&#160;&#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">train</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">play</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">view</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">export</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">deploy</tspan></text>
+
+  <!-- ============ stage headers ============ -->
+  <text x="168" y="104" text-anchor="middle" class="sans stage">DEFINE ONCE</text>
+  <text x="541" y="104" text-anchor="middle" class="sans stage">TRAIN FAST</text>
+  <text x="1008" y="104" text-anchor="middle" class="sans stage">DEPLOY ANYWHERE</text>
+
+  <!-- ============ stage 1: environment definition ============ -->
+  <rect x="36" y="130" width="264" height="158" rx="12" class="card"/>
+  <text x="168" y="160" text-anchor="middle" class="sans title">Environment definition</text>
+  <line x1="60" y1="174" x2="276" y2="174" stroke="#d0d7de" stroke-width="1"/>
+  <text x="64" y="198" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Observations &amp; actions</tspan></text>
+  <text x="64" y="224" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Rewards &amp; terminations</tspan></text>
+  <text x="64" y="250" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Scene, robot &amp; assets</tspan></text>
+  <text x="64" y="276" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">One shared config schema</tspan></text>
+
+  <text x="168" y="312" text-anchor="middle" class="sans" font-size="11" font-weight="600" letter-spacing="1.5" fill="#57606a">BUILT-IN LIBRARY</text>
+  <rect x="36" y="320" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Basic control</text>
+  <rect x="172" y="320" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Locomotion</text>
+  <rect x="36" y="354" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Manipulation</text>
+  <rect x="172" y="354" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Whole-body tracking</text>
+
+  <!-- ============ stage 2: training frameworks ============ -->
+  <rect x="386" y="130" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="163" class="sans chip">SKRL</text>
+  <rect x="593" y="146" width="97" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
+  <text x="641.5" y="162" text-anchor="middle" class="sans tag" fill="#4338ca">JAX &#183; PyTorch</text>
+
+  <rect x="386" y="200" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="233" class="sans chip">RSL-RL</text>
+  <rect x="629" y="216" width="61" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
+  <text x="659.5" y="232" text-anchor="middle" class="sans tag" fill="#4338ca">PyTorch</text>
+
+  <rect x="386" y="270" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="303" class="sans chip">FastSAC</text>
+  <rect x="618" y="286" width="72" height="24" rx="12" fill="#5450d6"/>
+  <text x="654" y="302" text-anchor="middle" class="sans tag" fill="#fefefe">built-in &#9733;</text>
+
+  <rect x="386" y="352" width="310" height="46" rx="10" fill="none" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="541" y="373" text-anchor="middle" class="sans" font-size="13" font-weight="600" fill="#1f2328">Thousands of parallel environments</text>
+  <text x="541" y="392" text-anchor="middle" class="sans" font-size="13" fill="#57606a">on <tspan fill="#4f46e5" font-weight="700">MotrixSim</tspan></text>
+
+  <!-- ============ artifact pill ============ -->
+  <rect x="736" y="206" width="132" height="64" rx="32" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.4"/>
+  <text x="802" y="234" text-anchor="middle" class="sans" font-size="13" font-weight="700" fill="#4338ca">policy artifact</text>
+  <text x="802" y="252" text-anchor="middle" class="mono" font-size="11" fill="#57606a">.onnx / .pt</text>
+
+  <!-- ============ stage 3: deployment targets ============ -->
+  <rect x="892" y="144" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="168" class="sans chip">MuJoCo</text>
+  <text x="912" y="187" class="sans sub">simulation replay</text>
+  <rect x="1054" y="158" width="50" height="24" rx="12" fill="#ddf4ff" stroke="#54aeff" stroke-width="1"/>
+  <text x="1079" y="174" text-anchor="middle" class="sans tag" font-size="11" fill="#0550ae">SIM</text>
+
+  <rect x="892" y="208" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="232" class="sans chip">Unitree</text>
+  <text x="912" y="251" class="sans sub">real hardware &#183; DDS</text>
+  <rect x="1054" y="222" width="50" height="24" rx="12" fill="#dafbe1" stroke="#4ac26b" stroke-width="1"/>
+  <text x="1079" y="238" text-anchor="middle" class="sans tag" font-size="11" fill="#1a7f37">REAL</text>
+
+  <rect x="892" y="272" width="232" height="52" rx="10" fill="none" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="1008" y="295" text-anchor="middle" class="sans" font-size="13.5" font-weight="700" fill="#57606a">+ more hardware</text>
+  <text x="1008" y="313" text-anchor="middle" class="sans sub" font-size="11.5">on the roadmap</text>
+
+  <!-- ============ connectors ============ -->
+  <path class="flow" d="M 300 235 C 338 235 348 158 386 158"/>
+  <path class="flow" d="M 300 235 C 338 235 348 228 386 228"/>
+  <path class="flow" d="M 300 235 C 338 235 348 298 386 298"/>
+  <path class="flow" d="M 696 158 C 716 158 716 238 736 238"/>
+  <path class="flow" d="M 696 228 C 712 228 720 238 736 238"/>
+  <path class="flow" d="M 696 298 C 716 298 716 238 736 238"/>
+  <path class="flow" d="M 868 238 C 880 238 880 170 892 170"/>
+  <path class="flow" d="M 868 238 C 880 238 880 234 892 234"/>
+  <path class="flow-future" d="M 868 238 C 880 238 880 298 892 298"/>
+
+  <!-- ============ takeaway badges ============ -->
+  <rect x="49" y="424" width="238" height="38" rx="19" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
+  <text x="168" y="448" text-anchor="middle" class="sans badge">One definition, every framework</text>
+
+  <rect x="430" y="424" width="232" height="38" rx="19" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
+  <text x="546" y="448" text-anchor="middle" class="sans badge">Minutes to converge, not hours</text>
+
+  <rect x="892" y="424" width="232" height="38" rx="19" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
+  <text x="1008" y="448" text-anchor="middle" class="sans badge">From sim to real, one artifact</text>
+</svg>

--- a/docs/source/_static/images/microduck-training-curves.png
+++ b/docs/source/_static/images/microduck-training-curves.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:10d117976d6a131a416d8ac34610ea0278996262bc1adf88cba5e52d755fe999
+size 72359

--- a/docs/source/_static/images/microduck-walk.gif
+++ b/docs/source/_static/images/microduck-walk.gif
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ce7ac578ac164229e669e7351ca87bebf3935a68993ebec280191a912e6d230d
+size 5759289

--- a/docs/source/_static/images/train-console.png
+++ b/docs/source/_static/images/train-console.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:74d03422c67b62e68002e34ff3a0b8844fd82fcd4e8fb62f23d40cdc3abf4ae1
+size 39922

--- a/docs/source/_static/videos/microduck-walk.mp4
+++ b/docs/source/_static/videos/microduck-walk.mp4
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e38fff19a52577c8f437e9c4d389c50fcec0be77eb125a432e2923aef35c2bb6
+size 1585145

--- a/motrix_rl/pyproject.toml
+++ b/motrix_rl/pyproject.toml
@@ -21,13 +21,13 @@ dependencies = [
     "numpy>=1.26",
     "omegaconf>=2.3,<2.4",
     "nvidia-ml-py>=13.610.43",
+    # Default training backend; also required by scripts/view.py. Resolved
+    # from the pytorch-cu128 index via the workspace root tool.uv.sources.
+    "torch==2.7.0",
 ]
 
 [project.optional-dependencies]
-onnx = [
-    "onnx==1.20.1",
-    "onnxruntime==1.23.2",
-]
+onnx = ["onnx==1.20.1", "onnxruntime==1.23.2"]
 skrl-jax = [
     "skrl>=2.1,<2.2; sys_platform == 'linux'",
     "jax[cuda12]==0.4.34; sys_platform == 'linux'",

--- a/scripts/view.py
+++ b/scripts/view.py
@@ -2,12 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
+from typing import TYPE_CHECKING
 
 import gymnasium as gym
 import hydra
 import motrixsim as mtx
 import numpy as np
-import torch
 from motrixsim.render import RenderApp, RenderClosedError, RenderSettings
 from omegaconf import DictConfig
 
@@ -19,10 +19,12 @@ from motrix_env_core.config import SimCfg
 from motrix_env_core.config.scene import RobotCfg, SystemCameraCfg
 from motrix_env_core.renderer import RenderConfig, create_renderer
 from motrix_env_motrixsim.compiler import build_scene_model
-from motrix_env_motrixsim.torch_env import TorchEnv
 from motrix_envs.config.scene import StandardSceneCfg, StandardSceneObjsCfg
 from motrix_rl.cli import to_typed_config
 from motrix_rl.config import ViewConfig
+
+if TYPE_CHECKING:
+    from motrix_env_motrixsim.torch_env import TorchEnv
 
 DEFAULT_ENV_NAME = "cartpole"
 ROBOT_VIEW_FPS = 60
@@ -137,7 +139,9 @@ def _run_robot(robot_cfg: RobotCfg, sim: str | None = None) -> None:
         raise ValueError(f"Unsupported robot view sim {backend!r}; expected 'motrixsim' or 'mujoco'")
 
 
-def _run_torch(env: TorchEnv):
+def _run_torch(env: "TorchEnv"):
+    import torch
+
     renderer = create_renderer(env, RenderConfig())
     env.init_state()
     env_dt = env.cfg.ctrl_dt
@@ -157,6 +161,13 @@ def _run_torch(env: TorchEnv):
             time.sleep(sleep_dt)
 
 
+def _torch_frontend_missing(env_name: str) -> ModuleNotFoundError:
+    return ModuleNotFoundError(
+        f"Environment '{env_name}' uses the torch frontend, but PyTorch is not installed; install torch "
+        f"(for example `uv sync --all-packages`) or view a NumPy-frontend environment such as '{DEFAULT_ENV_NAME}'"
+    )
+
+
 def run(cfg: ViewConfig) -> None:
     if cfg.env is not None and cfg.robot is not None:
         raise ValueError("env and robot are mutually exclusive; set only one")
@@ -167,11 +178,27 @@ def run(cfg: ViewConfig) -> None:
         _run_robot(registry.make_robot_config(cfg.robot), cfg.sim)
         return
 
-    env = registry.make(cfg.env or DEFAULT_ENV_NAME, num_envs=cfg.num_envs)
+    env_name = cfg.env or DEFAULT_ENV_NAME
+    try:
+        env = registry.make(env_name, num_envs=cfg.num_envs)
+    except ModuleNotFoundError as exc:
+        # Torch-frontend environments import torch when their factory resolves the env class.
+        if exc.name == "torch":
+            raise _torch_frontend_missing(env_name) from exc
+        raise
 
     if isinstance(env, ArrayEnv):
         _run_np(env)
-    elif isinstance(env, TorchEnv):
+        return
+
+    try:
+        from motrix_env_motrixsim.torch_env import TorchEnv
+    except ModuleNotFoundError as exc:
+        if exc.name == "torch":
+            raise _torch_frontend_missing(env_name) from exc
+        raise
+
+    if isinstance(env, TorchEnv):
         _run_torch(env)
     else:
         raise TypeError(f"Unsupported environment type '{type(env).__name__}'.")

--- a/uv.lock
+++ b/uv.lock
@@ -1094,6 +1094,8 @@ dependencies = [
     { name = "omegaconf" },
     { name = "python-abc" },
     { name = "rich" },
+    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 
 [package.optional-dependencies]
@@ -1154,6 +1156,8 @@ requires-dist = [
     { name = "skrl", marker = "sys_platform == 'linux' and extra == 'skrl-jax'", specifier = ">=2.1,<2.2" },
     { name = "skrl", marker = "extra == 'skrl-torch'", specifier = ">=2.1,<2.2" },
     { name = "tensorflow", marker = "sys_platform == 'linux' and extra == 'skrl-jax'", specifier = "==2.20.0" },
+    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32'", specifier = "==2.7.0" },
+    { name = "torch", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'rslrl') or (sys_platform == 'win32' and extra == 'rslrl')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "(sys_platform == 'linux' and extra == 'skrl-torch') or (sys_platform == 'win32' and extra == 'skrl-torch')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
     { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'rslrl'", specifier = "==2.7.0" },


### PR DESCRIPTION
Closes #19

## Summary

- Add light/dark architecture diagram (SVG + `<picture>` theme switching) after the intro: define once → train fast (SKRL / RSL-RL / FastSAC) → deploy anywhere, with built-in environment categories and a roadmap placeholder for future hardware
- Rework Quick Start: embed the microduck training console screenshot, TensorBoard curves, and the GitHub-hosted demo video (auto-embedded player in the replay section)
- Add two new sections after Quick Start following the user-guide style: Task Environments (quadruped / humanoid / WBT with gallery screenshots) and Built-in Robot Models (7 robots with renders, registry names, DoF)
- Key features: high-precision + high-performance MotrixSim wording with docs link; Sim-to-Real bullet now emphasizes one policy codebase via Sim2Sim (MuJoCo) and Sim2Real (real hardware)
- Fix stale package count (ten → nine) in AGENTS.md and CONTRIBUTING.md
- Track `*.gif` via LFS so the 5.5 MB hero GIF does not enter git history
- Add table of contents and center standalone figures; point gallery links to readthedocs latest

## Notes

- `docs/source/_static/videos/microduck-walk.mp4` intentionally left uncommitted (kept locally for upcoming user-guide pages)
- Recommend squash merge