### PR TITLE
feat: add ROCm support for AMD training via cuda/rocm extras

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@
 
 ## Validation
 
-- [ ] `uv run pytest -q`
+- [ ] `python -m pytest -q`
 - [ ] `prek run --all-files`
 - [ ] CI checks pass on the target branch
 - [ ] Documentation updated (if applicable)

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,7 +33,7 @@ jobs:
         run: uv python install 3.10
 
       - name: Install workspace and test dependencies
-        run: uv sync --all-packages --all-groups --all-extras
+        run: sh install.sh --all
 
       - name: Run tests
-        run: uv run pytest -q --disable-warnings --maxfail=1
+        run: .venv/bin/python -m pytest -q --disable-warnings --maxfail=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -104,19 +104,21 @@ Python 方法，由 manager 运行时契约定义（`wiki/design/manager/runtime
 
 项目使用 UV 管理依赖，Python 版本要求 3.10.\*。可用的依赖组与 extras 见 `pyproject.toml`。
 
-完整安装（含全部 package、依赖组与 extras）：
+完整开发环境（全部 package、依赖组与 extras；`--gpu rocm` 切换 AMD wheel）：
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+sh install.sh --all
 ```
 
-按框架安装：
+运行环境（无开发工具链；GPU 厂商自动探测，`--rslrl` 换后端）：
 
 ```bash
-uv sync --all-packages --extra skrl-jax   # SKRL JAX backend
-uv sync --all-packages --extra skrl-torch # SKRL PyTorch backend
-uv sync --all-packages --extra rslrl      # RSLRL（PyTorch）
+sh install.sh
 ```
+
+避免裸 `uv run` / `uv sync`：`cuda`/`rocm` extras 声明为互斥，裸命令会解析到默认 fork（PyPI torch）
+并重装环境。运行命令先 `source .venv/bin/activate`，之后直接 `python` / `pytest`（下文示例即此写法），
+或对单条命令使用 `uv run --no-sync`。依赖变更（`pyproject.toml` / `uv.lock`）后重新执行对应 install 命令。
 
 ## 常用命令
 
@@ -128,20 +130,20 @@ train/play/view CLI 由 [Hydra](https://hydra.cc/) 驱动，参数使用 `key=va
 SKRL（默认）：
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
 ```
 
 RSLRL：
 
 ```bash
-uv run scripts/train.py task=cartpole/rslrl.ppo
+python scripts/train.py task=cartpole/rslrl.ppo
 ```
 
 直接覆写框架运行时设置和类型化 RL 参数：
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo num_envs=64 algo.agent.learning_rate=1e-3
-uv run scripts/train.py task=cartpole/skrl.ppo logging.interval=20 checkpoint.interval=100
+python scripts/train.py task=cartpole/skrl.ppo num_envs=64 algo.agent.learning_rate=1e-3
+python scripts/train.py task=cartpole/skrl.ppo logging.interval=20 checkpoint.interval=100
 ```
 
 ### 环境可视化
@@ -149,31 +151,31 @@ uv run scripts/train.py task=cartpole/skrl.ppo logging.interval=20 checkpoint.in
 不训练只查看环境：
 
 ```bash
-uv run scripts/view.py env=cartpole
+python scripts/view.py env=cartpole
 ```
 
 查看内置机器人（不创建 RL 环境）：
 
 ```bash
-uv run scripts/view.py robot=g1-29dof
+python scripts/view.py robot=g1-29dof
 ```
 
 ### 评估
 
 ```bash
-uv run scripts/play.py env=cartpole
+python scripts/play.py env=cartpole
 ```
 
 指定 policy 文件：
 
 ```bash
-uv run scripts/play.py env=cartpole policy=<path/to/best.[pickle/pt]>
+python scripts/play.py env=cartpole policy=<path/to/best.[pickle/pt]>
 ```
 
 ### ONNX 导出
 
 ```bash
-uv run scripts/export_onnx.py run_dir=<run-dir> output=/tmp/policy.onnx
+python scripts/export_onnx.py run_dir=<run-dir> output=/tmp/policy.onnx
 ```
 
 ### 渲染
@@ -181,19 +183,19 @@ uv run scripts/export_onnx.py run_dir=<run-dir> output=/tmp/policy.onnx
 训练时开启可视化：
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo render=true
+python scripts/train.py task=cartpole/skrl.ppo render=true
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/{env-name}
+tensorboard --logdir runs/{env-name}
 ```
 
 ### 测试
 
 ```bash
-uv run pytest
+python -m pytest
 ```
 
 ## 架构要点

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,17 +26,16 @@ git lfs pull
 Create the complete development environment from the repository root:
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+sh install.sh --all       # --gpu rocm switches to the AMD wheels
 ```
 
-Optional training backends can be installed separately when a full environment
-is unnecessary:
-
-```bash
-uv sync --all-packages --extra skrl-torch
-uv sync --all-packages --extra skrl-jax   # Linux only
-uv sync --all-packages --extra rslrl
-```
+A runtime-only environment without the dev toolchain is available via `sh install.sh`: it
+auto-detects the GPU vendor (NVIDIA/AMD) for the torch wheels and `--rslrl`
+selects the RSLRL backend. On Windows, run `install.ps1` in PowerShell. Avoid bare
+`uv sync` / `uv run`: the `cuda`/`rocm` extras are declared conflicting, so a bare
+command resolves the default fork (PyPI torch) and reinstalls the environment. Run
+commands from the activated environment (`source .venv/bin/activate`); the examples
+below assume it is active, or pass `--no-sync` to one-off `uv run` calls.
 
 The workspace contains nine packages. Package-local changes should use the
 smallest required extra; changes involving the simulator, built-in assets, or
@@ -168,15 +167,15 @@ branch unless the change specifically requires them.
 Run the full test suite before opening a pull request:
 
 ```bash
-uv run pytest -q
+python -m pytest -q
 ```
 
 For an iteration on one package, run its tests directly, then run the full
 suite before requesting review:
 
 ```bash
-uv run pytest motrix_env_core/tests -q
-uv run pytest motrix_deploy/tests motrix_deploy_mujoco/tests -q
+python -m pytest motrix_env_core/tests -q
+python -m pytest motrix_deploy/tests motrix_deploy_mujoco/tests -q
 ```
 
 Run the repository's formatting, license-header, and lint hooks:
@@ -190,17 +189,16 @@ prek run --all-files
 The hooks run Copywrite, Ruff, and dprint. For individual checks, use:
 
 ```bash
-uv run ruff check .
-uv run ruff format --check .
-uv run mypy
+ruff check .
+ruff format --check .
+mypy
 ```
 
-When changing documentation, install the `docs` extra and build with warnings
-treated as errors:
+When changing documentation, build with warnings treated as errors (`sh install.sh --all`
+or a runtime install with `--docs` provides the required docs toolchain):
 
 ```bash
-uv sync --all-packages --extra docs
-uv run sphinx-build -W -b html docs/source docs/build/html
+sphinx-build -W -b html docs/source docs/build/html
 ```
 
 The public CI runs the complete workspace test command on Linux for both

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ _Microduck locomotion policies trained with MotrixLab, rendered in MotrixRender 
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/source/_static/images/architecture-dark.svg">
-    <img src="docs/source/_static/images/architecture-light.svg" alt="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments, then deploy the same policy artifact to MuJoCo or Unitree hardware" width="720">
+    <img src="docs/source/_static/images/architecture-light.svg" alt="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments running on NVIDIA CUDA or AMD ROCm GPUs, then deploy the same policy artifact to MuJoCo or Unitree hardware" width="100%">
   </picture>
 </div>
 
@@ -60,6 +60,7 @@ _Microduck locomotion policies trained with MotrixLab, rendered in MotrixRender 
 | [uv](https://docs.astral.sh/uv/) | Python project and dependency manager — [installation guide](https://docs.astral.sh/uv/getting-started/installation/) |
 | [Git LFS](https://git-lfs.com) | Robot meshes, motion data, and videos are tracked by LFS |
 | OS | Linux x86_64 or Windows x86_64; the JAX training backend is Linux-only |
+| GPU | NVIDIA (CUDA) or AMD (ROCm) — the matching wheels are selected automatically by `sh install.sh` |
 
 ### 1. Clone the repository
 
@@ -71,16 +72,29 @@ git lfs pull
 
 ### 2. Install dependencies
 
+Linux:
+
 ```bash
-uv sync --all-packages
+sh install.sh
 ```
 
-This installs all workspace packages together with **PyTorch**, the default training backend used by the built-in FastSAC. Third-party frameworks such as SKRL and RSLRL are optional extras.
+Windows (PowerShell):
+
+```powershell
+.\install.ps1
+# if blocked by the execution policy:
+powershell -ExecutionPolicy Bypass -File install.ps1
+```
+
+This auto-detects your GPU vendor (NVIDIA → CUDA, AMD → ROCm) and installs all workspace packages with the matching PyTorch wheels. Use `--gpu cuda|rocm` to override detection and `--skrl-jax` / `--rslrl` to add training backends — see `sh install.sh --help`.
 
 ### 3. Train your first policy
 
+Activate the installed environment (Windows PowerShell: `.venv\Scripts\Activate.ps1`):
+
 ```bash
-uv run scripts/train.py task=microduck-walk-flat/motrix.fastsac play=true
+source .venv/bin/activate
+python scripts/train.py task=microduck-walk-flat/motrix.fastsac play=true
 ```
 
 While training, the built-in dashboard shows live run progress, episode statistics, throughput, rewards, and system health:
@@ -92,7 +106,7 @@ While training, the built-in dashboard shows live run progress, episode statisti
 Training runs thousands of parallel environment instances; when it finishes, the trained policy is loaded and played in the viewer automatically. Checkpoints and TensorBoard logs are saved under `runs/microduck-walk-flat/`; watch the curves with:
 
 ```bash
-uv run tensorboard --logdir runs/microduck-walk-flat
+tensorboard --logdir runs/microduck-walk-flat
 ```
 
 Training finishes in minutes: mean return and episode length typically converge after about 4,000 iterations:
@@ -106,7 +120,7 @@ Training finishes in minutes: mean return and episode length typically converge 
 Replay the latest trained policy without retraining (for example, after stopping training early with Ctrl+C):
 
 ```bash
-uv run scripts/play.py env=microduck-walk-flat
+python scripts/play.py env=microduck-walk-flat
 ```
 
 A trained microduck policy replayed in the viewer:
@@ -124,7 +138,7 @@ MotrixLab ships 50+ built-in simulation environments spanning basic control, qua
 | <img src="docs/source/_static/images/poster/g1-wbt-dance.jpg" alt="g1-wbt-dance" width="240"> | Whole-body tracking (WBT) | `g1-wbt-dance` · `k1-wbt-freekick` · `g1-29dof-wbt-largebox` |
 
 ```bash
-uv run scripts/view.py env=go2-walk-rough
+python scripts/view.py env=go2-walk-rough
 ```
 
 See the [full environment gallery](https://motrixlab.readthedocs.io/en/latest/user_guide/envs/index.html) for all registered environments and their supported training algorithms.
@@ -144,7 +158,7 @@ Seven reusable robot models are registered out of the box and can be combined in
 | <img src="docs/source/_static/images/robots/microduck.png" alt="microduck" width="180"> | `microduck` | Humanoid | 14 |
 
 ```bash
-uv run scripts/view.py robot=go2
+python scripts/view.py robot=go2
 ```
 
 See [Supported Robots](https://motrixlab.readthedocs.io/en/latest/user_guide/robots.html) for configuration details and how to add your own model.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,7 +37,7 @@ _使用 MotrixLab 训练的 microduck 行走策略，由 MotrixRender 实时渲�
 <div align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="docs/source/_static/images/architecture-dark.svg">
-    <img src="docs/source/_static/images/architecture-light.svg" alt="MotrixLab 架构：环境只需定义一次，即可用 SKRL、RSL-RL 或 FastSAC 在数千个并行 MotrixSim 环境上训练，同一策略产物可部署到 MuJoCo 或 Unitree 硬件" width="720">
+    <img src="docs/source/_static/images/architecture-light.svg" alt="MotrixLab 架构：环境只需定义一次，即可用 SKRL、RSL-RL 或 FastSAC 在数千个并行 MotrixSim 环境上训练（支持 NVIDIA CUDA 与 AMD ROCm GPU），同一策略产物可部署到 MuJoCo 或 Unitree 硬件" width="100%">
   </picture>
 </div>
 
@@ -60,6 +60,7 @@ _使用 MotrixLab 训练的 microduck 行走策略，由 MotrixRender 实时渲�
 | [uv](https://docs.astral.sh/uv/) | Python 项目与依赖管理工具 — [安装指南](https://docs.astral.sh/uv/getting-started/installation/) |
 | [Git LFS](https://git-lfs.com) | 机器人网格、运动数据与视频由 LFS 管理 |
 | 操作系统 | Linux x86_64 或 Windows x86_64；JAX 训练后端仅支持 Linux |
+| GPU | NVIDIA（CUDA）或 AMD（ROCm）——`sh install.sh` 自动选择对应 wheel |
 
 ### 1. 克隆仓库
 
@@ -71,16 +72,29 @@ git lfs pull
 
 ### 2. 安装依赖
 
+Linux：
+
 ```bash
-uv sync --all-packages
+sh install.sh
 ```
 
-该命令会安装全部 workspace package，以及内置 FastSAC 所需的默认训练后端 **PyTorch**。SKRL、RSLRL 等第三方训练框架为可选 extras。
+Windows（PowerShell）：
+
+```powershell
+.\install.ps1
+# 若提示执行策略受限：
+powershell -ExecutionPolicy Bypass -File install.ps1
+```
+
+脚本会自动探测 GPU 厂商（NVIDIA → CUDA，AMD → ROCm），安装全部 workspace package 及对应的 PyTorch wheel。可用 `--gpu cuda|rocm` 显式指定 GPU，`--skrl-jax` / `--rslrl` 追加训练后端——详见 `sh install.sh --help`。
 
 ### 3. 训练第一个策略
 
+先激活安装好的环境（Windows PowerShell：`.venv\Scripts\Activate.ps1`）：
+
 ```bash
-uv run scripts/train.py task=microduck-walk-flat/motrix.fastsac play=true
+source .venv/bin/activate
+python scripts/train.py task=microduck-walk-flat/motrix.fastsac play=true
 ```
 
 训练过程中，内置面板会实时显示运行进度、回合统计、吞吐、奖励与系统健康状态：
@@ -92,7 +106,7 @@ uv run scripts/train.py task=microduck-walk-flat/motrix.fastsac play=true
 训练会启动数千个并行环境实例；训练结束后会自动加载策略并在查看器中回放。checkpoint 与 TensorBoard 日志保存在 `runs/microduck-walk-flat/` 目录下，通过以下命令查看训练曲线：
 
 ```bash
-uv run tensorboard --logdir runs/microduck-walk-flat
+tensorboard --logdir runs/microduck-walk-flat
 ```
 
 microduck 的训练数分钟内即可完成：平均回报与回合长度通常在约 4,000 次迭代后收敛：
@@ -106,7 +120,7 @@ microduck 的训练数分钟内即可完成：平均回报与回合长度通常�
 无需重新训练即可回放最近一次训练得到的策略（例如提前 Ctrl+C 中断训练之后）：
 
 ```bash
-uv run scripts/play.py env=microduck-walk-flat
+python scripts/play.py env=microduck-walk-flat
 ```
 
 训练好的 microduck 策略在查看器中的回放效果：
@@ -124,7 +138,7 @@ MotrixLab 内置 50+ 个仿真环境，覆盖基础控制、四足、人形、�
 | <img src="docs/source/_static/images/poster/g1-wbt-dance.jpg" alt="g1-wbt-dance" width="240"> | 全身动作跟踪（WBT） | `g1-wbt-dance` · `k1-wbt-freekick` · `g1-29dof-wbt-largebox` |
 
 ```bash
-uv run scripts/view.py env=go2-walk-rough
+python scripts/view.py env=go2-walk-rough
 ```
 
 完整环境列表与各环境支持的训练算法见[环境总览](https://motrixlab.readthedocs.io/zh-cn/latest/user_guide/envs/index.html)。
@@ -144,7 +158,7 @@ uv run scripts/view.py env=go2-walk-rough
 | <img src="docs/source/_static/images/robots/microduck.png" alt="microduck" width="180"> | `microduck` | 人形机器人 | 14 |
 
 ```bash
-uv run scripts/view.py robot=go2
+python scripts/view.py robot=go2
 ```
 
 机器人配置细节与自定义新模型的方法见[支持的机器人](https://motrixlab.readthedocs.io/zh-cn/latest/user_guide/robots.html)。

--- a/configs/task/microduck-walk-flat/motrix.fastsac.yaml
+++ b/configs/task/microduck-walk-flat/motrix.fastsac.yaml
@@ -16,4 +16,8 @@ algo:
   agent:
     alpha_init: 0.01
     target_entropy_ratio: -0.1
+    batch_size: 2048
     num_updates: 4
+  trainer:
+    async_options:
+      utd_mode: strict

--- a/docs/source/_static/images/architecture-dark.svg
+++ b/docs/source/_static/images/architecture-dark.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="500" viewBox="0 0 1160 500" role="img" aria-label="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments, then deploy the same policy artifact to MuJoCo or Unitree hardware, with more hardware backends planned. Built-in environments cover basic control, locomotion, manipulation and whole-body tracking.">
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="576" viewBox="0 0 1160 576" role="img" aria-label="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments running on NVIDIA CUDA or AMD ROCm GPUs, then deploy the same policy artifact to MuJoCo or Unitree hardware, with more hardware backends planned. Built-in environments cover basic control, locomotion, manipulation and whole-body tracking.">
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#818cf8"/>
@@ -13,102 +13,113 @@
     .body    { font-size: 13.5px; fill: #e6edf3; }
     .sub     { font-size: 12px; fill: #9198a1; }
     .tag     { font-size: 11.5px; font-weight: 600; }
-    .badge   { font-size: 12.5px; font-weight: 600; fill: #a5b4fc; }
+    .label   { font-size: 11px; font-weight: 600; letter-spacing: 1.5px; fill: #9198a1; }
+    .pill    { font-size: 11.5px; fill: #e6edf3; }
+    .slogan  { font-size: 17px; font-weight: 800; fill: #ffffff; }
     .card    { fill: #161b22; stroke: #30363d; stroke-width: 1.2; }
     .flow    { fill: none; stroke: #818cf8; stroke-width: 1.8; marker-end: url(#arrow); }
     .flow-future { fill: none; stroke: #818cf8; stroke-width: 1.8; stroke-dasharray: 5 4; opacity: 0.7; marker-end: url(#arrow); }
   </style>
 
-  <rect x="0" y="0" width="1160" height="500" rx="18" fill="#0d1117"/>
+  <rect x="0" y="0" width="1160" height="576" rx="18" fill="#0d1117"/>
 
-  <!-- ============ top CLI bar ============ -->
-  <rect x="36" y="24" width="1088" height="40" rx="20" class="card"/>
-  <text x="580" y="49" text-anchor="middle" class="sans" font-size="13"><tspan font-weight="700" fill="#e6edf3">One CLI, end to end:&#160;&#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">train</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">play</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">view</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">export</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">deploy</tspan></text>
+  <!-- ============ slogan banners ============ -->
+  <rect x="36" y="24" width="344" height="56" rx="16" fill="#6366f1"/>
+  <text x="208" y="58" text-anchor="middle" class="sans slogan">One definition, every framework</text>
+
+  <rect x="408" y="24" width="344" height="56" rx="16" fill="#6366f1"/>
+  <text x="580" y="58" text-anchor="middle" class="sans slogan">Minutes to converge, not hours</text>
+
+  <rect x="780" y="24" width="344" height="56" rx="16" fill="#6366f1"/>
+  <text x="952" y="58" text-anchor="middle" class="sans slogan">From sim to real, one artifact</text>
 
   <!-- ============ stage headers ============ -->
-  <text x="168" y="104" text-anchor="middle" class="sans stage">DEFINE ONCE</text>
-  <text x="541" y="104" text-anchor="middle" class="sans stage">TRAIN FAST</text>
-  <text x="1008" y="104" text-anchor="middle" class="sans stage">DEPLOY ANYWHERE</text>
+  <text x="168" y="124" text-anchor="middle" class="sans stage">DEFINE ONCE</text>
+  <text x="541" y="124" text-anchor="middle" class="sans stage">TRAIN FAST</text>
+  <text x="1008" y="124" text-anchor="middle" class="sans stage">DEPLOY ANYWHERE</text>
 
   <!-- ============ stage 1: environment definition ============ -->
-  <rect x="36" y="130" width="264" height="158" rx="12" class="card"/>
-  <text x="168" y="160" text-anchor="middle" class="sans title">Environment definition</text>
-  <line x1="60" y1="174" x2="276" y2="174" stroke="#30363d" stroke-width="1"/>
-  <text x="64" y="198" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Observations &amp; actions</tspan></text>
-  <text x="64" y="224" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Rewards &amp; terminations</tspan></text>
-  <text x="64" y="250" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Scene, robot &amp; assets</tspan></text>
-  <text x="64" y="276" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">One shared config schema</tspan></text>
+  <rect x="36" y="150" width="264" height="158" rx="12" class="card"/>
+  <text x="168" y="180" text-anchor="middle" class="sans title">Environment definition</text>
+  <line x1="60" y1="194" x2="276" y2="194" stroke="#30363d" stroke-width="1"/>
+  <text x="64" y="218" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Observations &amp; actions</tspan></text>
+  <text x="64" y="244" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Rewards &amp; terminations</tspan></text>
+  <text x="64" y="270" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">Scene, robot &amp; assets</tspan></text>
+  <text x="64" y="296" class="sans body"><tspan fill="#818cf8">&#9656;</tspan><tspan dx="8">One shared config schema</tspan></text>
 
-  <text x="168" y="312" text-anchor="middle" class="sans" font-size="11" font-weight="600" letter-spacing="1.5" fill="#9198a1">BUILT-IN LIBRARY</text>
-  <rect x="36" y="320" width="128" height="26" rx="13" class="card"/>
-  <text x="100" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Basic control</text>
-  <rect x="172" y="320" width="128" height="26" rx="13" class="card"/>
-  <text x="236" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Locomotion</text>
-  <rect x="36" y="354" width="128" height="26" rx="13" class="card"/>
-  <text x="100" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Manipulation</text>
-  <rect x="172" y="354" width="128" height="26" rx="13" class="card"/>
-  <text x="236" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Whole-body tracking</text>
+  <text x="168" y="336" text-anchor="middle" class="sans label">BUILT-IN LIBRARY</text>
+  <rect x="36" y="344" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="361" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Basic control</text>
+  <rect x="172" y="344" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="361" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Locomotion</text>
+  <rect x="36" y="378" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="395" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Manipulation</text>
+  <rect x="172" y="378" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="395" text-anchor="middle" class="sans" font-size="11.5" fill="#e6edf3">Whole-body tracking</text>
 
   <!-- ============ stage 2: training frameworks ============ -->
-  <rect x="386" y="130" width="310" height="56" rx="10" class="card"/>
-  <text x="406" y="163" class="sans chip">SKRL</text>
-  <rect x="593" y="146" width="97" height="24" rx="12" fill="#202542" stroke="#3b4468" stroke-width="1"/>
-  <text x="641.5" y="162" text-anchor="middle" class="sans tag" fill="#a5b4fc">JAX &#183; PyTorch</text>
+  <rect x="386" y="150" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="183" class="sans chip">SKRL</text>
+  <rect x="593" y="166" width="97" height="24" rx="12" fill="#202542" stroke="#3b4468" stroke-width="1"/>
+  <text x="641.5" y="182" text-anchor="middle" class="sans tag" fill="#a5b4fc">JAX &#183; PyTorch</text>
 
-  <rect x="386" y="200" width="310" height="56" rx="10" class="card"/>
-  <text x="406" y="233" class="sans chip">RSL-RL</text>
-  <rect x="629" y="216" width="61" height="24" rx="12" fill="#202542" stroke="#3b4468" stroke-width="1"/>
-  <text x="659.5" y="232" text-anchor="middle" class="sans tag" fill="#a5b4fc">PyTorch</text>
+  <rect x="386" y="224" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="257" class="sans chip">RSL-RL</text>
+  <rect x="629" y="240" width="61" height="24" rx="12" fill="#202542" stroke="#3b4468" stroke-width="1"/>
+  <text x="659.5" y="256" text-anchor="middle" class="sans tag" fill="#a5b4fc">PyTorch</text>
 
-  <rect x="386" y="270" width="310" height="56" rx="10" class="card"/>
-  <text x="406" y="303" class="sans chip">FastSAC</text>
-  <rect x="618" y="286" width="72" height="24" rx="12" fill="#5450d6"/>
-  <text x="654" y="302" text-anchor="middle" class="sans tag" fill="#fefefe">built-in &#9733;</text>
+  <rect x="386" y="298" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="331" class="sans chip">FastSAC</text>
+  <rect x="618" y="314" width="72" height="24" rx="12" fill="#5450d6"/>
+  <text x="654" y="330" text-anchor="middle" class="sans tag" fill="#fefefe">built-in &#9733;</text>
 
-  <rect x="386" y="352" width="310" height="46" rx="10" fill="none" stroke="#30363d" stroke-width="1.2" stroke-dasharray="5 4"/>
-  <text x="541" y="373" text-anchor="middle" class="sans" font-size="13" font-weight="600" fill="#e6edf3">Thousands of parallel environments</text>
-  <text x="541" y="392" text-anchor="middle" class="sans" font-size="13" fill="#9198a1">on <tspan fill="#818cf8" font-weight="700">MotrixSim</tspan></text>
+  <rect x="386" y="376" width="310" height="50" rx="10" fill="none" stroke="#30363d" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="541" y="398" text-anchor="middle" class="sans" font-size="13" font-weight="600" fill="#e6edf3">Thousands of parallel environments</text>
+  <text x="541" y="417" text-anchor="middle" class="sans" font-size="13" fill="#9198a1">on <tspan fill="#818cf8" font-weight="700">MotrixSim</tspan></text>
+
+  <!-- ============ gpu backends ============ -->
+  <text x="541" y="453" text-anchor="middle" class="sans label">GPU BACKENDS</text>
+  <rect x="386" y="462" width="145" height="28" rx="14" class="card"/>
+  <g transform="translate(405 468) scale(0.6667)" fill="#76b900"><path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z"/></g>
+  <text x="428" y="480" class="sans pill">NVIDIA &#183; CUDA</text>
+  <rect x="551" y="462" width="145" height="28" rx="14" class="card"/>
+  <g transform="translate(540.5 448) scale(2.27)" fill="#e6edf3"><path d="M18.324 9.137l1.559 1.56h2.556v2.557L24 14.814V9.137zM19.881 11.01l-1.604 1.603v2.25h2.246l1.604-1.607h-2.246z"/></g>
+  <text x="603" y="480" class="sans pill">AMD &#183; ROCm</text>
 
   <!-- ============ artifact pill ============ -->
-  <rect x="736" y="206" width="132" height="64" rx="32" fill="#202542" stroke="#818cf8" stroke-width="1.4"/>
-  <text x="802" y="234" text-anchor="middle" class="sans" font-size="13" font-weight="700" fill="#a5b4fc">policy artifact</text>
-  <text x="802" y="252" text-anchor="middle" class="mono" font-size="11" fill="#9198a1">.onnx / .pt</text>
+  <rect x="736" y="220" width="132" height="64" rx="32" fill="#202542" stroke="#818cf8" stroke-width="1.4"/>
+  <text x="802" y="248" text-anchor="middle" class="sans" font-size="13" font-weight="700" fill="#a5b4fc">policy artifact</text>
+  <text x="802" y="266" text-anchor="middle" class="mono" font-size="11" fill="#9198a1">.onnx / .pt</text>
 
   <!-- ============ stage 3: deployment targets ============ -->
-  <rect x="892" y="144" width="232" height="52" rx="10" class="card"/>
-  <text x="912" y="168" class="sans chip">MuJoCo</text>
-  <text x="912" y="187" class="sans sub">simulation replay</text>
-  <rect x="1054" y="158" width="50" height="24" rx="12" fill="#102a45" stroke="#4493f8" stroke-width="1"/>
-  <text x="1079" y="174" text-anchor="middle" class="sans tag" font-size="11" fill="#4493f8">SIM</text>
+  <rect x="892" y="164" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="188" class="sans chip">MuJoCo</text>
+  <text x="912" y="207" class="sans sub">simulation replay</text>
+  <rect x="1054" y="178" width="50" height="24" rx="12" fill="#102a45" stroke="#4493f8" stroke-width="1"/>
+  <text x="1079" y="194" text-anchor="middle" class="sans tag" font-size="11" fill="#4493f8">SIM</text>
 
-  <rect x="892" y="208" width="232" height="52" rx="10" class="card"/>
-  <text x="912" y="232" class="sans chip">Unitree</text>
-  <text x="912" y="251" class="sans sub">real hardware &#183; DDS</text>
-  <rect x="1054" y="222" width="50" height="24" rx="12" fill="#122d1f" stroke="#2ea043" stroke-width="1"/>
-  <text x="1079" y="238" text-anchor="middle" class="sans tag" font-size="11" fill="#3fb950">REAL</text>
+  <rect x="892" y="228" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="252" class="sans chip">Unitree</text>
+  <text x="912" y="271" class="sans sub">real hardware &#183; DDS</text>
+  <rect x="1054" y="242" width="50" height="24" rx="12" fill="#122d1f" stroke="#2ea043" stroke-width="1"/>
+  <text x="1079" y="258" text-anchor="middle" class="sans tag" font-size="11" fill="#3fb950">REAL</text>
 
-  <rect x="892" y="272" width="232" height="52" rx="10" fill="none" stroke="#30363d" stroke-width="1.2" stroke-dasharray="5 4"/>
-  <text x="1008" y="295" text-anchor="middle" class="sans" font-size="13.5" font-weight="700" fill="#9198a1">+ more hardware</text>
-  <text x="1008" y="313" text-anchor="middle" class="sans sub" font-size="11.5">on the roadmap</text>
+  <rect x="892" y="292" width="232" height="52" rx="10" fill="none" stroke="#30363d" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="1008" y="315" text-anchor="middle" class="sans" font-size="13.5" font-weight="700" fill="#9198a1">+ more hardware</text>
+  <text x="1008" y="333" text-anchor="middle" class="sans sub" font-size="11.5">on the roadmap</text>
 
   <!-- ============ connectors ============ -->
-  <path class="flow" d="M 300 235 C 338 235 348 158 386 158"/>
-  <path class="flow" d="M 300 235 C 338 235 348 228 386 228"/>
-  <path class="flow" d="M 300 235 C 338 235 348 298 386 298"/>
-  <path class="flow" d="M 696 158 C 716 158 716 238 736 238"/>
-  <path class="flow" d="M 696 228 C 712 228 720 238 736 238"/>
-  <path class="flow" d="M 696 298 C 716 298 716 238 736 238"/>
-  <path class="flow" d="M 868 238 C 880 238 880 170 892 170"/>
-  <path class="flow" d="M 868 238 C 880 238 880 234 892 234"/>
-  <path class="flow-future" d="M 868 238 C 880 238 880 298 892 298"/>
+  <path class="flow" d="M 300 229 C 338 229 348 178 386 178"/>
+  <path class="flow" d="M 300 229 C 338 229 348 252 386 252"/>
+  <path class="flow" d="M 300 229 C 338 229 348 326 386 326"/>
+  <path class="flow" d="M 696 178 C 716 178 716 252 736 252"/>
+  <path class="flow" d="M 696 252 C 712 252 720 252 736 252"/>
+  <path class="flow" d="M 696 326 C 716 326 716 252 736 252"/>
+  <path class="flow" d="M 868 252 C 880 252 880 190 892 190"/>
+  <path class="flow" d="M 868 252 C 880 252 880 254 892 254"/>
+  <path class="flow-future" d="M 868 252 C 880 252 880 318 892 318"/>
 
-  <!-- ============ takeaway badges ============ -->
-  <rect x="49" y="424" width="238" height="38" rx="19" fill="#202542" stroke="#3b4468" stroke-width="1"/>
-  <text x="168" y="448" text-anchor="middle" class="sans badge">One definition, every framework</text>
-
-  <rect x="430" y="424" width="232" height="38" rx="19" fill="#202542" stroke="#3b4468" stroke-width="1"/>
-  <text x="546" y="448" text-anchor="middle" class="sans badge">Minutes to converge, not hours</text>
-
-  <rect x="892" y="424" width="232" height="38" rx="19" fill="#202542" stroke="#3b4468" stroke-width="1"/>
-  <text x="1008" y="448" text-anchor="middle" class="sans badge">From sim to real, one artifact</text>
+  <!-- ============ bottom CLI bar ============ -->
+  <rect x="36" y="512" width="1088" height="40" rx="20" class="card"/>
+  <text x="580" y="537" text-anchor="middle" class="sans" font-size="13"><tspan font-weight="700" fill="#e6edf3">One CLI, end to end:&#160;&#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">train</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">play</tspan><tspan fill="#9198a1">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#818cf8">deploy</tspan></text>
 </svg>

--- a/docs/source/_static/images/architecture-light.svg
+++ b/docs/source/_static/images/architecture-light.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="500" viewBox="0 0 1160 500" role="img" aria-label="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments, then deploy the same policy artifact to MuJoCo or Unitree hardware, with more hardware backends planned. Built-in environments cover basic control, locomotion, manipulation and whole-body tracking.">
+<svg xmlns="http://www.w3.org/2000/svg" width="1160" height="576" viewBox="0 0 1160 576" role="img" aria-label="MotrixLab architecture: define an environment once, train it with SKRL, RSL-RL or FastSAC on thousands of parallel MotrixSim environments running on NVIDIA CUDA or AMD ROCm GPUs, then deploy the same policy artifact to MuJoCo or Unitree hardware, with more hardware backends planned. Built-in environments cover basic control, locomotion, manipulation and whole-body tracking.">
   <defs>
     <marker id="arrow" viewBox="0 0 10 10" refX="8" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
       <path d="M 0 0 L 10 5 L 0 10 z" fill="#4f46e5"/>
@@ -13,102 +13,113 @@
     .body    { font-size: 13.5px; fill: #1f2328; }
     .sub     { font-size: 12px; fill: #57606a; }
     .tag     { font-size: 11.5px; font-weight: 600; }
-    .badge   { font-size: 12.5px; font-weight: 600; fill: #4338ca; }
+    .label   { font-size: 11px; font-weight: 600; letter-spacing: 1.5px; fill: #57606a; }
+    .pill    { font-size: 11.5px; fill: #1f2328; }
+    .slogan  { font-size: 17px; font-weight: 800; fill: #ffffff; }
     .card    { fill: #ffffff; stroke: #d0d7de; stroke-width: 1.2; }
     .flow    { fill: none; stroke: #4f46e5; stroke-width: 1.8; marker-end: url(#arrow); }
     .flow-future { fill: none; stroke: #4f46e5; stroke-width: 1.8; stroke-dasharray: 5 4; opacity: 0.7; marker-end: url(#arrow); }
   </style>
 
-  <rect x="0" y="0" width="1160" height="500" rx="18" fill="#f6f8fa"/>
+  <rect x="0" y="0" width="1160" height="576" rx="18" fill="#f6f8fa"/>
 
-  <!-- ============ top CLI bar ============ -->
-  <rect x="36" y="24" width="1088" height="40" rx="20" class="card"/>
-  <text x="580" y="49" text-anchor="middle" class="sans" font-size="13"><tspan font-weight="700" fill="#1f2328">One CLI, end to end:&#160;&#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">train</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">play</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">view</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">export</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">deploy</tspan></text>
+  <!-- ============ slogan banners ============ -->
+  <rect x="36" y="24" width="344" height="56" rx="16" fill="#4f46e5"/>
+  <text x="208" y="58" text-anchor="middle" class="sans slogan">One definition, every framework</text>
+
+  <rect x="408" y="24" width="344" height="56" rx="16" fill="#4f46e5"/>
+  <text x="580" y="58" text-anchor="middle" class="sans slogan">Minutes to converge, not hours</text>
+
+  <rect x="780" y="24" width="344" height="56" rx="16" fill="#4f46e5"/>
+  <text x="952" y="58" text-anchor="middle" class="sans slogan">From sim to real, one artifact</text>
 
   <!-- ============ stage headers ============ -->
-  <text x="168" y="104" text-anchor="middle" class="sans stage">DEFINE ONCE</text>
-  <text x="541" y="104" text-anchor="middle" class="sans stage">TRAIN FAST</text>
-  <text x="1008" y="104" text-anchor="middle" class="sans stage">DEPLOY ANYWHERE</text>
+  <text x="168" y="124" text-anchor="middle" class="sans stage">DEFINE ONCE</text>
+  <text x="541" y="124" text-anchor="middle" class="sans stage">TRAIN FAST</text>
+  <text x="1008" y="124" text-anchor="middle" class="sans stage">DEPLOY ANYWHERE</text>
 
   <!-- ============ stage 1: environment definition ============ -->
-  <rect x="36" y="130" width="264" height="158" rx="12" class="card"/>
-  <text x="168" y="160" text-anchor="middle" class="sans title">Environment definition</text>
-  <line x1="60" y1="174" x2="276" y2="174" stroke="#d0d7de" stroke-width="1"/>
-  <text x="64" y="198" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Observations &amp; actions</tspan></text>
-  <text x="64" y="224" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Rewards &amp; terminations</tspan></text>
-  <text x="64" y="250" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Scene, robot &amp; assets</tspan></text>
-  <text x="64" y="276" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">One shared config schema</tspan></text>
+  <rect x="36" y="150" width="264" height="158" rx="12" class="card"/>
+  <text x="168" y="180" text-anchor="middle" class="sans title">Environment definition</text>
+  <line x1="60" y1="194" x2="276" y2="194" stroke="#d0d7de" stroke-width="1"/>
+  <text x="64" y="218" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Observations &amp; actions</tspan></text>
+  <text x="64" y="244" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Rewards &amp; terminations</tspan></text>
+  <text x="64" y="270" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">Scene, robot &amp; assets</tspan></text>
+  <text x="64" y="296" class="sans body"><tspan fill="#4f46e5">&#9656;</tspan><tspan dx="8">One shared config schema</tspan></text>
 
-  <text x="168" y="312" text-anchor="middle" class="sans" font-size="11" font-weight="600" letter-spacing="1.5" fill="#57606a">BUILT-IN LIBRARY</text>
-  <rect x="36" y="320" width="128" height="26" rx="13" class="card"/>
-  <text x="100" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Basic control</text>
-  <rect x="172" y="320" width="128" height="26" rx="13" class="card"/>
-  <text x="236" y="337" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Locomotion</text>
-  <rect x="36" y="354" width="128" height="26" rx="13" class="card"/>
-  <text x="100" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Manipulation</text>
-  <rect x="172" y="354" width="128" height="26" rx="13" class="card"/>
-  <text x="236" y="371" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Whole-body tracking</text>
+  <text x="168" y="336" text-anchor="middle" class="sans label">BUILT-IN LIBRARY</text>
+  <rect x="36" y="344" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="361" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Basic control</text>
+  <rect x="172" y="344" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="361" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Locomotion</text>
+  <rect x="36" y="378" width="128" height="26" rx="13" class="card"/>
+  <text x="100" y="395" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Manipulation</text>
+  <rect x="172" y="378" width="128" height="26" rx="13" class="card"/>
+  <text x="236" y="395" text-anchor="middle" class="sans" font-size="11.5" fill="#1f2328">Whole-body tracking</text>
 
   <!-- ============ stage 2: training frameworks ============ -->
-  <rect x="386" y="130" width="310" height="56" rx="10" class="card"/>
-  <text x="406" y="163" class="sans chip">SKRL</text>
-  <rect x="593" y="146" width="97" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
-  <text x="641.5" y="162" text-anchor="middle" class="sans tag" fill="#4338ca">JAX &#183; PyTorch</text>
+  <rect x="386" y="150" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="183" class="sans chip">SKRL</text>
+  <rect x="593" y="166" width="97" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
+  <text x="641.5" y="182" text-anchor="middle" class="sans tag" fill="#4338ca">JAX &#183; PyTorch</text>
 
-  <rect x="386" y="200" width="310" height="56" rx="10" class="card"/>
-  <text x="406" y="233" class="sans chip">RSL-RL</text>
-  <rect x="629" y="216" width="61" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
-  <text x="659.5" y="232" text-anchor="middle" class="sans tag" fill="#4338ca">PyTorch</text>
+  <rect x="386" y="224" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="257" class="sans chip">RSL-RL</text>
+  <rect x="629" y="240" width="61" height="24" rx="12" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
+  <text x="659.5" y="256" text-anchor="middle" class="sans tag" fill="#4338ca">PyTorch</text>
 
-  <rect x="386" y="270" width="310" height="56" rx="10" class="card"/>
-  <text x="406" y="303" class="sans chip">FastSAC</text>
-  <rect x="618" y="286" width="72" height="24" rx="12" fill="#5450d6"/>
-  <text x="654" y="302" text-anchor="middle" class="sans tag" fill="#fefefe">built-in &#9733;</text>
+  <rect x="386" y="298" width="310" height="56" rx="10" class="card"/>
+  <text x="406" y="331" class="sans chip">FastSAC</text>
+  <rect x="618" y="314" width="72" height="24" rx="12" fill="#5450d6"/>
+  <text x="654" y="330" text-anchor="middle" class="sans tag" fill="#fefefe">built-in &#9733;</text>
 
-  <rect x="386" y="352" width="310" height="46" rx="10" fill="none" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="5 4"/>
-  <text x="541" y="373" text-anchor="middle" class="sans" font-size="13" font-weight="600" fill="#1f2328">Thousands of parallel environments</text>
-  <text x="541" y="392" text-anchor="middle" class="sans" font-size="13" fill="#57606a">on <tspan fill="#4f46e5" font-weight="700">MotrixSim</tspan></text>
+  <rect x="386" y="376" width="310" height="50" rx="10" fill="none" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="541" y="398" text-anchor="middle" class="sans" font-size="13" font-weight="600" fill="#1f2328">Thousands of parallel environments</text>
+  <text x="541" y="417" text-anchor="middle" class="sans" font-size="13" fill="#57606a">on <tspan fill="#4f46e5" font-weight="700">MotrixSim</tspan></text>
+
+  <!-- ============ gpu backends ============ -->
+  <text x="541" y="453" text-anchor="middle" class="sans label">GPU BACKENDS</text>
+  <rect x="386" y="462" width="145" height="28" rx="14" class="card"/>
+  <g transform="translate(405 468) scale(0.6667)" fill="#76b900"><path d="M8.948 8.798v-1.43a6.7 6.7 0 0 1 .424-.018c3.922-.124 6.493 3.374 6.493 3.374s-2.774 3.851-5.75 3.851c-.398 0-.787-.062-1.158-.185v-4.346c1.528.185 1.837.857 2.747 2.385l2.04-1.714s-1.492-1.952-4-1.952a6.016 6.016 0 0 0-.796.035m0-4.735v2.138l.424-.027c5.45-.185 9.01 4.47 9.01 4.47s-4.08 4.964-8.33 4.964c-.37 0-.733-.035-1.095-.097v1.325c.3.035.61.062.91.062 3.957 0 6.82-2.023 9.593-4.408.459.371 2.34 1.263 2.73 1.652-2.633 2.208-8.772 3.984-12.253 3.984-.335 0-.653-.018-.971-.053v1.864H24V4.063zm0 10.326v1.131c-3.657-.654-4.673-4.46-4.673-4.46s1.758-1.944 4.673-2.262v1.237H8.94c-1.528-.186-2.73 1.245-2.73 1.245s.68 2.412 2.739 3.11M2.456 10.9s2.164-3.197 6.5-3.533V6.201C4.153 6.59 0 10.653 0 10.653s2.35 6.802 8.948 7.42v-1.237c-4.84-.6-6.492-5.936-6.492-5.936z"/></g>
+  <text x="428" y="480" class="sans pill">NVIDIA &#183; CUDA</text>
+  <rect x="551" y="462" width="145" height="28" rx="14" class="card"/>
+  <g transform="translate(540.5 448) scale(2.27)" fill="#1f2328"><path d="M18.324 9.137l1.559 1.56h2.556v2.557L24 14.814V9.137zM19.881 11.01l-1.604 1.603v2.25h2.246l1.604-1.607h-2.246z"/></g>
+  <text x="603" y="480" class="sans pill">AMD &#183; ROCm</text>
 
   <!-- ============ artifact pill ============ -->
-  <rect x="736" y="206" width="132" height="64" rx="32" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.4"/>
-  <text x="802" y="234" text-anchor="middle" class="sans" font-size="13" font-weight="700" fill="#4338ca">policy artifact</text>
-  <text x="802" y="252" text-anchor="middle" class="mono" font-size="11" fill="#57606a">.onnx / .pt</text>
+  <rect x="736" y="220" width="132" height="64" rx="32" fill="#eef2ff" stroke="#4f46e5" stroke-width="1.4"/>
+  <text x="802" y="248" text-anchor="middle" class="sans" font-size="13" font-weight="700" fill="#4338ca">policy artifact</text>
+  <text x="802" y="266" text-anchor="middle" class="mono" font-size="11" fill="#57606a">.onnx / .pt</text>
 
   <!-- ============ stage 3: deployment targets ============ -->
-  <rect x="892" y="144" width="232" height="52" rx="10" class="card"/>
-  <text x="912" y="168" class="sans chip">MuJoCo</text>
-  <text x="912" y="187" class="sans sub">simulation replay</text>
-  <rect x="1054" y="158" width="50" height="24" rx="12" fill="#ddf4ff" stroke="#54aeff" stroke-width="1"/>
-  <text x="1079" y="174" text-anchor="middle" class="sans tag" font-size="11" fill="#0550ae">SIM</text>
+  <rect x="892" y="164" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="188" class="sans chip">MuJoCo</text>
+  <text x="912" y="207" class="sans sub">simulation replay</text>
+  <rect x="1054" y="178" width="50" height="24" rx="12" fill="#ddf4ff" stroke="#54aeff" stroke-width="1"/>
+  <text x="1079" y="194" text-anchor="middle" class="sans tag" font-size="11" fill="#0550ae">SIM</text>
 
-  <rect x="892" y="208" width="232" height="52" rx="10" class="card"/>
-  <text x="912" y="232" class="sans chip">Unitree</text>
-  <text x="912" y="251" class="sans sub">real hardware &#183; DDS</text>
-  <rect x="1054" y="222" width="50" height="24" rx="12" fill="#dafbe1" stroke="#4ac26b" stroke-width="1"/>
-  <text x="1079" y="238" text-anchor="middle" class="sans tag" font-size="11" fill="#1a7f37">REAL</text>
+  <rect x="892" y="228" width="232" height="52" rx="10" class="card"/>
+  <text x="912" y="252" class="sans chip">Unitree</text>
+  <text x="912" y="271" class="sans sub">real hardware &#183; DDS</text>
+  <rect x="1054" y="242" width="50" height="24" rx="12" fill="#dafbe1" stroke="#4ac26b" stroke-width="1"/>
+  <text x="1079" y="258" text-anchor="middle" class="sans tag" font-size="11" fill="#1a7f37">REAL</text>
 
-  <rect x="892" y="272" width="232" height="52" rx="10" fill="none" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="5 4"/>
-  <text x="1008" y="295" text-anchor="middle" class="sans" font-size="13.5" font-weight="700" fill="#57606a">+ more hardware</text>
-  <text x="1008" y="313" text-anchor="middle" class="sans sub" font-size="11.5">on the roadmap</text>
+  <rect x="892" y="292" width="232" height="52" rx="10" fill="none" stroke="#d0d7de" stroke-width="1.2" stroke-dasharray="5 4"/>
+  <text x="1008" y="315" text-anchor="middle" class="sans" font-size="13.5" font-weight="700" fill="#57606a">+ more hardware</text>
+  <text x="1008" y="333" text-anchor="middle" class="sans sub" font-size="11.5">on the roadmap</text>
 
   <!-- ============ connectors ============ -->
-  <path class="flow" d="M 300 235 C 338 235 348 158 386 158"/>
-  <path class="flow" d="M 300 235 C 338 235 348 228 386 228"/>
-  <path class="flow" d="M 300 235 C 338 235 348 298 386 298"/>
-  <path class="flow" d="M 696 158 C 716 158 716 238 736 238"/>
-  <path class="flow" d="M 696 228 C 712 228 720 238 736 238"/>
-  <path class="flow" d="M 696 298 C 716 298 716 238 736 238"/>
-  <path class="flow" d="M 868 238 C 880 238 880 170 892 170"/>
-  <path class="flow" d="M 868 238 C 880 238 880 234 892 234"/>
-  <path class="flow-future" d="M 868 238 C 880 238 880 298 892 298"/>
+  <path class="flow" d="M 300 229 C 338 229 348 178 386 178"/>
+  <path class="flow" d="M 300 229 C 338 229 348 252 386 252"/>
+  <path class="flow" d="M 300 229 C 338 229 348 326 386 326"/>
+  <path class="flow" d="M 696 178 C 716 178 716 252 736 252"/>
+  <path class="flow" d="M 696 252 C 712 252 720 252 736 252"/>
+  <path class="flow" d="M 696 326 C 716 326 716 252 736 252"/>
+  <path class="flow" d="M 868 252 C 880 252 880 190 892 190"/>
+  <path class="flow" d="M 868 252 C 880 252 880 254 892 254"/>
+  <path class="flow-future" d="M 868 252 C 880 252 880 318 892 318"/>
 
-  <!-- ============ takeaway badges ============ -->
-  <rect x="49" y="424" width="238" height="38" rx="19" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
-  <text x="168" y="448" text-anchor="middle" class="sans badge">One definition, every framework</text>
-
-  <rect x="430" y="424" width="232" height="38" rx="19" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
-  <text x="546" y="448" text-anchor="middle" class="sans badge">Minutes to converge, not hours</text>
-
-  <rect x="892" y="424" width="232" height="38" rx="19" fill="#eef2ff" stroke="#c7d2fe" stroke-width="1"/>
-  <text x="1008" y="448" text-anchor="middle" class="sans badge">From sim to real, one artifact</text>
+  <!-- ============ bottom CLI bar ============ -->
+  <rect x="36" y="512" width="1088" height="40" rx="20" class="card"/>
+  <text x="580" y="537" text-anchor="middle" class="sans" font-size="13"><tspan font-weight="700" fill="#1f2328">One CLI, end to end:&#160;&#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">train</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">play</tspan><tspan fill="#57606a">&#160; &#183; &#160;</tspan><tspan class="mono" font-size="12.5" fill="#4f46e5">deploy</tspan></text>
 </svg>

--- a/docs/source/en/user_guide/envs/basic/acrobot.md
+++ b/docs/source/en/user_guide/envs/basic/acrobot.md
@@ -63,36 +63,36 @@ Order: `upper_arm_horizontal, lower_arm_horizontal, upper_arm_vertical, lower_ar
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=acrobot
+python scripts/view.py env=acrobot
 ```
 
 ### 2. Start Training
 
 ```bash
 # Train with default parameters
-uv run scripts/train.py task=acrobot/skrl.ppo
+python scripts/train.py task=acrobot/skrl.ppo
 
 # Customize parallel environments
-uv run scripts/train.py task=acrobot/skrl.ppo num_envs=1024
+python scripts/train.py task=acrobot/skrl.ppo num_envs=1024
 
 # Enable rendering during training
-uv run scripts/train.py task=acrobot/skrl.ppo render=true
+python scripts/train.py task=acrobot/skrl.ppo render=true
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/acrobot
+tensorboard --logdir runs/acrobot
 ```
 
 ### 4. Test Training Results
 
 ```bash
 # Auto-discover best policy (recommended)
-uv run scripts/play.py env=acrobot
+python scripts/play.py env=acrobot
 
 # Manually specify a checkpoint from a metadata-backed run
-uv run scripts/play.py env=acrobot policy=/path/to/run/checkpoints/policy-file
+python scripts/play.py env=acrobot policy=/path/to/run/checkpoints/policy-file
 ```
 
 > **Tip**: Policies are auto-selected from `runs/acrobot/`. Use `policy=...` to select a checkpoint whose parent run contains `metadata.json`.

--- a/docs/source/en/user_guide/envs/basic/cartpole.md
+++ b/docs/source/en/user_guide/envs/basic/cartpole.md
@@ -15,25 +15,25 @@ CartPole is a classic control task in reinforcement learning. The goal is to kee
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=cartpole
+python scripts/view.py env=cartpole
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/cartpole
+tensorboard --logdir runs/cartpole
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=cartpole
+python scripts/play.py env=cartpole
 ```
 
 > **Tip**: The system finds the latest metadata-backed run under `runs/cartpole/` and loads its `best_policy` artifact. Use `policy=...` to select another checkpoint from a metadata-backed run.

--- a/docs/source/en/user_guide/envs/basic/pendulum.md
+++ b/docs/source/en/user_guide/envs/basic/pendulum.md
@@ -62,36 +62,36 @@ Order: `cos(theta), sin(theta), angular velocity`.
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=pendulum
+python scripts/view.py env=pendulum
 ```
 
 ### 2. Start Training
 
 ```bash
 # Train with default parameters
-uv run scripts/train.py task=pendulum/skrl.ppo
+python scripts/train.py task=pendulum/skrl.ppo
 
 # Customize parallel environments
-uv run scripts/train.py task=pendulum/skrl.ppo num_envs=1024
+python scripts/train.py task=pendulum/skrl.ppo num_envs=1024
 
 # Enable rendering during training
-uv run scripts/train.py task=pendulum/skrl.ppo render=true
+python scripts/train.py task=pendulum/skrl.ppo render=true
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/pendulum
+tensorboard --logdir runs/pendulum
 ```
 
 ### 4. Test Training Results
 
 ```bash
 # Auto-discover best policy (recommended)
-uv run scripts/play.py env=pendulum
+python scripts/play.py env=pendulum
 
 # Manually specify a checkpoint from a metadata-backed run
-uv run scripts/play.py env=pendulum policy=/path/to/run/checkpoints/policy-file
+python scripts/play.py env=pendulum policy=/path/to/run/checkpoints/policy-file
 ```
 
 > **Tip**: Policies are auto-selected from `runs/pendulum/`. Use `policy=...` to select a checkpoint whose parent run contains `metadata.json`.

--- a/docs/source/en/user_guide/envs/basic/stewart.md
+++ b/docs/source/en/user_guide/envs/basic/stewart.md
@@ -156,15 +156,15 @@ An episode terminates when any of the following is true:
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=stewart-static
-uv run scripts/view.py env=stewart-disturb-xy
+python scripts/view.py env=stewart-static
+python scripts/view.py env=stewart-disturb-xy
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=stewart-static/skrl.ppo
-uv run scripts/train.py task=stewart-disturb-xy/skrl.ppo
+python scripts/train.py task=stewart-static/skrl.ppo
+python scripts/train.py task=stewart-disturb-xy/skrl.ppo
 ```
 
 ### Training Notes
@@ -176,15 +176,15 @@ uv run scripts/train.py task=stewart-disturb-xy/skrl.ppo
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/stewart-static
-uv run tensorboard --logdir runs/stewart-disturb-xy
+tensorboard --logdir runs/stewart-static
+tensorboard --logdir runs/stewart-disturb-xy
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=stewart-static
-uv run scripts/play.py env=stewart-disturb-xy
+python scripts/play.py env=stewart-static
+python scripts/play.py env=stewart-disturb-xy
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/bring_ball.md
+++ b/docs/source/en/user_guide/envs/dm_control/bring_ball.md
@@ -137,25 +137,25 @@ Default weights (from `BringBallCfg`):
 ### 1. Environment Preview (random actions)
 
 ```bash
-uv run scripts/view.py env=dm-manipulator-bring-ball
+python scripts/view.py env=dm-manipulator-bring-ball
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-manipulator-bring-ball/skrl.ppo.torch
+python scripts/train.py task=dm-manipulator-bring-ball/skrl.ppo.torch
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-manipulator-bring-ball
+tensorboard --logdir runs/dm-manipulator-bring-ball
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-manipulator-bring-ball
+python scripts/play.py env=dm-manipulator-bring-ball
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_cheetah.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_cheetah.md
@@ -102,25 +102,25 @@ The cheetah's reward function consists of the following parts:
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=dm-cheetah
+python scripts/view.py env=dm-cheetah
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-cheetah/skrl.ppo
+python scripts/train.py task=dm-cheetah/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-cheetah
+tensorboard --logdir runs/dm-cheetah
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-cheetah
+python scripts/play.py env=dm-cheetah
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_finger.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_finger.md
@@ -131,35 +131,35 @@ If `NaN` appears in the observations
 ### 1. Environment Preview (random actions)
 
 ```bash
-uv run scripts/view.py env=dm-finger-spin
+python scripts/view.py env=dm-finger-spin
 ```
 
 ```bash
-uv run scripts/view.py env=dm-finger-turn-easy
+python scripts/view.py env=dm-finger-turn-easy
 ```
 
 ```bash
-uv run scripts/view.py env=dm-finger-turn-hard
+python scripts/view.py env=dm-finger-turn-hard
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-finger-spin/skrl.ppo task.train_backend=torch
+python scripts/train.py task=dm-finger-spin/skrl.ppo task.train_backend=torch
 ```
 
 ```bash
-uv run scripts/train.py task=dm-finger-turn-easy/skrl.ppo task.train_backend=torch
+python scripts/train.py task=dm-finger-turn-easy/skrl.ppo task.train_backend=torch
 ```
 
 ```bash
-uv run scripts/train.py task=dm-finger-turn-hard/skrl.ppo task.train_backend=torch
+python scripts/train.py task=dm-finger-turn-hard/skrl.ppo task.train_backend=torch
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-finger-spin
+tensorboard --logdir runs/dm-finger-spin
 ```
 
 ### 4. Test Training Results
@@ -167,7 +167,7 @@ uv run tensorboard --logdir runs/dm-finger-spin
 `scripts/play.py` auto-discovers the latest metadata-backed run under `runs/{env-name}/` and loads its `best_policy` artifact. Use `policy=...` to select a checkpoint explicitly:
 
 ```bash
-uv run scripts/play.py env=dm-finger-turn-hard
+python scripts/play.py env=dm-finger-turn-hard
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_hopper.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_hopper.md
@@ -108,28 +108,28 @@ The Hopper reward consists of the following terms:
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=dm-hopper-stand
-uv run scripts/view.py env=dm-hopper-hop
+python scripts/view.py env=dm-hopper-stand
+python scripts/view.py env=dm-hopper-hop
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-hopper-stand/skrl.ppo
-uv run scripts/train.py task=dm-hopper-hop/skrl.ppo
+python scripts/train.py task=dm-hopper-stand/skrl.ppo
+python scripts/train.py task=dm-hopper-hop/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-hopper-stand
+tensorboard --logdir runs/dm-hopper-stand
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-hopper-stand
-uv run scripts/play.py env=dm-hopper-hop
+python scripts/play.py env=dm-hopper-stand
+python scripts/play.py env=dm-hopper-hop
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_humanoid.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_humanoid.md
@@ -185,31 +185,31 @@ total_reward = posture_reward * speed_reward * energy_reward * gait_reward
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=dm-humanoid-stand
-uv run scripts/view.py env=dm-humanoid-walk
-uv run scripts/view.py env=dm-humanoid-run
+python scripts/view.py env=dm-humanoid-stand
+python scripts/view.py env=dm-humanoid-walk
+python scripts/view.py env=dm-humanoid-run
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-humanoid-stand/skrl.ppo
-uv run scripts/train.py task=dm-humanoid-walk/skrl.ppo
-uv run scripts/train.py task=dm-humanoid-run/skrl.ppo
+python scripts/train.py task=dm-humanoid-stand/skrl.ppo
+python scripts/train.py task=dm-humanoid-walk/skrl.ppo
+python scripts/train.py task=dm-humanoid-run/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-humanoid-walk
+tensorboard --logdir runs/dm-humanoid-walk
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-humanoid-stand
-uv run scripts/play.py env=dm-humanoid-walk
-uv run scripts/play.py env=dm-humanoid-run
+python scripts/play.py env=dm-humanoid-stand
+python scripts/play.py env=dm-humanoid-walk
+python scripts/play.py env=dm-humanoid-run
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_lqr.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_lqr.md
@@ -157,29 +157,29 @@ An episode terminates and resets when any of the following conditions is met:
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=dm-lqr-2-1
-uv run scripts/view.py env=dm-lqr-6-2
+python scripts/view.py env=dm-lqr-2-1
+python scripts/view.py env=dm-lqr-6-2
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-lqr-2-1/skrl.ppo
-uv run scripts/train.py task=dm-lqr-6-2/skrl.ppo
+python scripts/train.py task=dm-lqr-2-1/skrl.ppo
+python scripts/train.py task=dm-lqr-6-2/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-lqr-2-1
-uv run tensorboard --logdir runs/dm-lqr-6-2
+tensorboard --logdir runs/dm-lqr-2-1
+tensorboard --logdir runs/dm-lqr-6-2
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-lqr-2-1
-uv run scripts/play.py env=dm-lqr-6-2
+python scripts/play.py env=dm-lqr-2-1
+python scripts/play.py env=dm-lqr-6-2
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_point_mass.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_point_mass.md
@@ -115,25 +115,25 @@ rwd = distance_reward + target_bonus + continuous_reward + path_reward - center_
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=point_mass
+python scripts/view.py env=point_mass
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=point_mass/skrl.ppo
+python scripts/train.py task=point_mass/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/point_mass
+tensorboard --logdir runs/point_mass
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=point_mass
+python scripts/play.py env=point_mass
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_quadruped.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_quadruped.md
@@ -228,37 +228,37 @@ In addition, `fetch` uses a `stability` gate on torso uprightness and torso heig
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=dm-quadruped-walk
-uv run scripts/view.py env=dm-quadruped-run
-uv run scripts/view.py env=dm-quadruped-escape
-uv run scripts/view.py env=dm-quadruped-fetch
+python scripts/view.py env=dm-quadruped-walk
+python scripts/view.py env=dm-quadruped-run
+python scripts/view.py env=dm-quadruped-escape
+python scripts/view.py env=dm-quadruped-fetch
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-quadruped-walk/skrl.ppo
-uv run scripts/train.py task=dm-quadruped-run/skrl.ppo
-uv run scripts/train.py task=dm-quadruped-escape/skrl.ppo
-uv run scripts/train.py task=dm-quadruped-fetch/skrl.ppo
+python scripts/train.py task=dm-quadruped-walk/skrl.ppo
+python scripts/train.py task=dm-quadruped-run/skrl.ppo
+python scripts/train.py task=dm-quadruped-escape/skrl.ppo
+python scripts/train.py task=dm-quadruped-fetch/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-quadruped-walk
-uv run tensorboard --logdir runs/dm-quadruped-run
-uv run tensorboard --logdir runs/dm-quadruped-escape
-uv run tensorboard --logdir runs/dm-quadruped-fetch
+tensorboard --logdir runs/dm-quadruped-walk
+tensorboard --logdir runs/dm-quadruped-run
+tensorboard --logdir runs/dm-quadruped-escape
+tensorboard --logdir runs/dm-quadruped-fetch
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-quadruped-walk
-uv run scripts/play.py env=dm-quadruped-run
-uv run scripts/play.py env=dm-quadruped-escape
-uv run scripts/play.py env=dm-quadruped-fetch
+python scripts/play.py env=dm-quadruped-walk
+python scripts/play.py env=dm-quadruped-run
+python scripts/play.py env=dm-quadruped-escape
+python scripts/play.py env=dm-quadruped-fetch
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/dm_control/dm_reacher.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_reacher.md
@@ -102,25 +102,25 @@ terminated = True
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=dm-reacher
+python scripts/view.py env=dm-reacher
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-reacher/skrl.ppo
+python scripts/train.py task=dm-reacher/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-reacher
+tensorboard --logdir runs/dm-reacher
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-reacher
+python scripts/play.py env=dm-reacher
 ```
 
 ## Expected Training Results

--- a/docs/source/en/user_guide/envs/dm_control/dm_walker.md
+++ b/docs/source/en/user_guide/envs/dm_control/dm_walker.md
@@ -26,19 +26,19 @@ Walker2D is a 2D planar bipedal robot with multiple joints and actuators:
 1. **dm-stander**: Static standing task (move_speed = 0.0)
 
 ```bash
-uv run scripts/train.py task=dm-stander/skrl.ppo
+python scripts/train.py task=dm-stander/skrl.ppo
 ```
 
 2. **dm-walker**: Walking task (move_speed = 1.0)
 
 ```bash
-uv run scripts/train.py task=dm-walker/skrl.ppo
+python scripts/train.py task=dm-walker/skrl.ppo
 ```
 
 3. **dm-runner**: Running task (move_speed = 5.0)
 
 ```bash
-uv run scripts/train.py task=dm-runner/skrl.ppo
+python scripts/train.py task=dm-runner/skrl.ppo
 ```
 
 ## Quick Start
@@ -46,31 +46,31 @@ uv run scripts/train.py task=dm-runner/skrl.ppo
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=dm-stander
-uv run scripts/view.py env=dm-walker
-uv run scripts/view.py env=dm-runner
+python scripts/view.py env=dm-stander
+python scripts/view.py env=dm-walker
+python scripts/view.py env=dm-runner
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=dm-stander/skrl.ppo
-uv run scripts/train.py task=dm-walker/skrl.ppo
-uv run scripts/train.py task=dm-runner/skrl.ppo
+python scripts/train.py task=dm-stander/skrl.ppo
+python scripts/train.py task=dm-walker/skrl.ppo
+python scripts/train.py task=dm-runner/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/dm-walker
+tensorboard --logdir runs/dm-walker
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=dm-stander
-uv run scripts/play.py env=dm-walker
-uv run scripts/play.py env=dm-runner
+python scripts/play.py env=dm-stander
+python scripts/play.py env=dm-walker
+python scripts/play.py env=dm-runner
 ```
 
 ## Reward Function Design

--- a/docs/source/en/user_guide/envs/humanoid_velocity_tracking.md
+++ b/docs/source/en/user_guide/envs/humanoid_velocity_tracking.md
@@ -93,15 +93,15 @@ weight and mean return may decrease; this is a change in reward scale rather tha
 Choose an environment ID and one of its training configs from the table, then replace `ENV_ID` and `TRAINING_CONFIG`:
 
 ```bash
-uv run scripts/view.py env=ENV_ID num_envs=1
-uv run scripts/train.py task=ENV_ID/TRAINING_CONFIG
-uv run scripts/play.py env=ENV_ID num_envs=16
+python scripts/view.py env=ENV_ID num_envs=1
+python scripts/train.py task=ENV_ID/TRAINING_CONFIG
+python scripts/play.py env=ENV_ID num_envs=16
 ```
 
 For example, train the K1 uneven-terrain task with asynchronous FastSAC:
 
 ```bash
-uv run scripts/train.py task=k1-walk-rough/motrix.fastsac algo.asynchronous=true
+python scripts/train.py task=k1-walk-rough/motrix.fastsac algo.asynchronous=true
 ```
 
 `view.py` applies random actions and is intended for scene and model inspection. Use `play.py` with a trained policy to

--- a/docs/source/en/user_guide/envs/humanoid_velocity_tracking/adding_robot.md
+++ b/docs/source/en/user_guide/envs/humanoid_velocity_tracking/adding_robot.md
@@ -118,7 +118,7 @@ environment construction.
 Preview the robot and verify joint ordering, the default pose, PD parameters, sole sites, and collision-geom names:
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
+python scripts/view.py robot=<robot-config-id>
 ```
 
 ## 4. Register the environment implementation
@@ -164,13 +164,13 @@ dynamics and training behavior.
 Use this progression:
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
-uv run scripts/view.py env=<robot>-walk-flat
-uv run scripts/view.py env=<robot>-walk-terrain
-uv run scripts/train.py task=<robot>-walk-flat/motrix.fastsac
-uv run scripts/train.py task=<robot>-walk-flat/motrix.fastsac algo.asynchronous=false
-uv run pytest motrix_envs/tests/test_humanoid_walk.py -q
-uv run pytest motrix_rl/tests/test_task_configs.py -q
+python scripts/view.py robot=<robot-config-id>
+python scripts/view.py env=<robot>-walk-flat
+python scripts/view.py env=<robot>-walk-terrain
+python scripts/train.py task=<robot>-walk-flat/motrix.fastsac
+python scripts/train.py task=<robot>-walk-flat/motrix.fastsac algo.asynchronous=false
+python -m pytest motrix_envs/tests/test_humanoid_walk.py -q
+python -m pytest motrix_rl/tests/test_task_configs.py -q
 ```
 
 During preview, inspect the default pose, sole height, ground contacts, action direction, and terrain spawn position. For

--- a/docs/source/en/user_guide/envs/index.md
+++ b/docs/source/en/user_guide/envs/index.md
@@ -5,7 +5,7 @@ A MotrixLab Environment is a simulation task created through the Env Registry. I
 Preview an environment without starting training:
 
 ```bash
-uv run scripts/view.py env=<env-id>
+python scripts/view.py env=<env-id>
 ```
 
 ## Environment topics

--- a/docs/source/en/user_guide/envs/manipulation/bounce_ball.md
+++ b/docs/source/en/user_guide/envs/manipulation/bounce_ball.md
@@ -411,25 +411,25 @@ Target height for each environment is randomly sampled in [0.4, 0.6] m range to 
 ### 1. Environment Preview
 
 ```bash
-uv run scripts/view.py env=bounce_ball
+python scripts/view.py env=bounce_ball
 ```
 
 ### 2. Start Training
 
 ```bash
-uv run scripts/train.py task=bounce_ball/skrl.ppo
+python scripts/train.py task=bounce_ball/skrl.ppo
 ```
 
 ### 3. View Training Progress
 
 ```bash
-uv run tensorboard --logdir runs/bounce_ball
+tensorboard --logdir runs/bounce_ball
 ```
 
 ### 4. Test Training Results
 
 ```bash
-uv run scripts/play.py env=bounce_ball
+python scripts/play.py env=bounce_ball
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/manipulation/franka_lift_cube.md
+++ b/docs/source/en/user_guide/envs/manipulation/franka_lift_cube.md
@@ -233,17 +233,17 @@ Target position is randomly sampled in the following range:
 ### Training
 
 ```bash
-uv run scripts/train.py task=franka-lift-cube/skrl.ppo
+python scripts/train.py task=franka-lift-cube/skrl.ppo
 ```
 
 ### Policy Evaluation
 
 ```bash
-uv run scripts/play.py env=franka-lift-cube
+python scripts/play.py env=franka-lift-cube
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/franka-lift-cube
+tensorboard --logdir runs/franka-lift-cube
 ```

--- a/docs/source/en/user_guide/envs/manipulation/franka_open_cabinet.md
+++ b/docs/source/en/user_guide/envs/manipulation/franka_open_cabinet.md
@@ -234,17 +234,17 @@ Cabinet is fixed on ground with drawer in closed state (joint position at 0).
 ### Training
 
 ```bash
-uv run scripts/train.py task=franka-open-cabinet/skrl.ppo
+python scripts/train.py task=franka-open-cabinet/skrl.ppo
 ```
 
 ### Policy Evaluation
 
 ```bash
-uv run scripts/play.py env=franka-open-cabinet
+python scripts/play.py env=franka-open-cabinet
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/franka-open-cabinet
+tensorboard --logdir runs/franka-open-cabinet
 ```

--- a/docs/source/en/user_guide/envs/manipulation/rm65_insert_peg.md
+++ b/docs/source/en/user_guide/envs/manipulation/rm65_insert_peg.md
@@ -269,17 +269,17 @@ The task currently provides an Async FastSAC configuration with `2048` parallel 
 ### Training
 
 ```bash
-uv run scripts/train.py task=rm65_insert_peg/motrix.fastsac
+python scripts/train.py task=rm65_insert_peg/motrix.fastsac
 ```
 
 ### Policy Evaluation
 
 ```bash
-uv run scripts/play.py env=rm65_insert_peg num_envs=16
+python scripts/play.py env=rm65_insert_peg num_envs=16
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/rm65_insert_peg/fastsac
+tensorboard --logdir runs/rm65_insert_peg/fastsac
 ```

--- a/docs/source/en/user_guide/envs/manipulation/rm65_open_cabinet.md
+++ b/docs/source/en/user_guide/envs/manipulation/rm65_open_cabinet.md
@@ -241,17 +241,17 @@ In addition, the maximum episode length is `30s`.
 ### Training
 
 ```bash
-uv run scripts/train.py task=rm65-open-cabinet/skrl.ppo task.train_backend=torch
+python scripts/train.py task=rm65-open-cabinet/skrl.ppo task.train_backend=torch
 ```
 
 ### Policy Evaluation
 
 ```bash
-uv run scripts/play.py env=rm65-open-cabinet
+python scripts/play.py env=rm65-open-cabinet
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/rm65_open_cabinet
+tensorboard --logdir runs/rm65_open_cabinet
 ```

--- a/docs/source/en/user_guide/envs/manipulation/shadow_hand_repose.md
+++ b/docs/source/en/user_guide/envs/manipulation/shadow_hand_repose.md
@@ -308,25 +308,25 @@ The environment uses a consecutive success counter:
 ### Training
 
 ```bash
-uv run scripts/train.py task=shadow-hand-repose/skrl.ppo
+python scripts/train.py task=shadow-hand-repose/skrl.ppo
 ```
 
 ### Policy Evaluation
 
 ```bash
-uv run scripts/play.py env=shadow-hand-repose
+python scripts/play.py env=shadow-hand-repose
 ```
 
 ### Environment Visualization
 
 ```bash
-uv run scripts/view.py env=shadow-hand-repose
+python scripts/view.py env=shadow-hand-repose
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/shadow-hand-repose
+tensorboard --logdir runs/shadow-hand-repose
 ```
 
 ---

--- a/docs/source/en/user_guide/envs/quadruped_locomotion/go1_rough_terrain.md
+++ b/docs/source/en/user_guide/envs/quadruped_locomotion/go1_rough_terrain.md
@@ -26,7 +26,7 @@ horizontal linear-speed sum exceeds $10^8$. The default `20 s` limit produces tr
 physical parameters.
 
 ```bash
-uv run scripts/view.py env=go1-stairs-terrain-walk
-uv run scripts/train.py task=go1-stairs-terrain-walk/skrl.ppo
-uv run scripts/play.py env=go1-stairs-terrain-walk
+python scripts/view.py env=go1-stairs-terrain-walk
+python scripts/train.py task=go1-stairs-terrain-walk/skrl.ppo
+python scripts/play.py env=go1-stairs-terrain-walk
 ```

--- a/docs/source/en/user_guide/envs/quadruped_velocity_tracking.md
+++ b/docs/source/en/user_guide/envs/quadruped_velocity_tracking.md
@@ -114,15 +114,15 @@ sustained rough-terrain locomotion. Under the current training configs and hardw
 Choose an environment ID and one of its training configs from the table, then replace `ENV_ID` and `TRAINING_CONFIG`:
 
 ```bash
-uv run scripts/view.py env=ENV_ID num_envs=1
-uv run scripts/train.py task=ENV_ID/TRAINING_CONFIG
-uv run scripts/play.py env=ENV_ID num_envs=16
+python scripts/view.py env=ENV_ID num_envs=1
+python scripts/train.py task=ENV_ID/TRAINING_CONFIG
+python scripts/play.py env=ENV_ID num_envs=16
 ```
 
 For example, train the Go2 rough-terrain task with RSL-RL PPO:
 
 ```bash
-uv run scripts/train.py task=go2-walk-rough/rslrl.ppo
+python scripts/train.py task=go2-walk-rough/rslrl.ppo
 ```
 
 `view.py` applies random actions and is intended for scene and model inspection. Use `play.py` with a trained policy to

--- a/docs/source/en/user_guide/envs/quadruped_velocity_tracking/adding_robot.md
+++ b/docs/source/en/user_guide/envs/quadruped_velocity_tracking/adding_robot.md
@@ -69,7 +69,7 @@ rejected. Every actuator must target a joint and expose a valid control range.
 After registering the robot config, preview it independently:
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
+python scripts/view.py robot=<robot-config-id>
 ```
 
 ## 2. Provide task sensors
@@ -197,10 +197,10 @@ inherit the same robot's flat-ground recipe and override only `task.env`.
 Use this progression:
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
-uv run scripts/view.py env=<robot>-walk-flat
-uv run scripts/view.py env=<robot>-walk-rough
-uv run scripts/train.py task=<robot>-walk-flat/rslrl.ppo
+python scripts/view.py robot=<robot-config-id>
+python scripts/view.py env=<robot>-walk-flat
+python scripts/view.py env=<robot>-walk-rough
+python scripts/train.py task=<robot>-walk-flat/rslrl.ppo
 ```
 
 During preview, inspect the default pose, action direction, all four foot contacts, foot-position reference frames, and

--- a/docs/source/en/user_guide/envs/whole_body_tracking/adding_wbt_task.md
+++ b/docs/source/en/user_guide/envs/whole_body_tracking/adding_wbt_task.md
@@ -43,7 +43,7 @@ Built-in WBT uses `ctrl_dt=0.02` s, so convert this motion to 50 FPS. Run kinema
 entry point:
 
 ```bash
-uv run scripts/motion/replay.py \
+python scripts/motion/replay.py \
   --robot g1-29dof \
   --motion motrix_envs/src/motrix_envs/locomotion/wbt/assets/motion/g1/dance1_subject1.npz
 ```
@@ -134,7 +134,7 @@ Task for the same robot first, and tune algorithm hyperparameters only after the
 Use a small smoke test for Hydra composition, registry creation, tensor shapes, and the training path:
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac \
+python scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac \
   algo.asynchronous=true num_envs=64 algo.trainer.num_learning_iterations=100
 ```
 
@@ -142,13 +142,13 @@ Check for missing motion, joint, or body names; systematic NaNs, joint-limit vio
 reset; and verify that `info["Reward"]` and `info["metrics"]` reach the logs. Then start the default training run:
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac algo.asynchronous=true
+python scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac algo.asynchronous=true
 ```
 
 After training creates a metadata-backed run, play the policy:
 
 ```bash
-uv run scripts/play.py env=g1-wbt-dance1-subject1 num_envs=16
+python scripts/play.py env=g1-wbt-dance1-subject1 num_envs=16
 ```
 
 Play mode starts at frame 0, disables reset noise and adaptive sampling, and restarts from the beginning at the clip end. A

--- a/docs/source/en/user_guide/envs/whole_body_tracking/index.md
+++ b/docs/source/en/user_guide/envs/whole_body_tracking/index.md
@@ -126,7 +126,7 @@ Motion files are managed by Git LFS. If an `.npz` is still pointer text after cl
 Check a reference motion with the target robot's `RobotCfg`:
 
 ```bash
-uv run scripts/motion/replay.py \
+python scripts/motion/replay.py \
   --robot g1-29dof \
   --motion motrix_envs/src/motrix_envs/locomotion/wbt/assets/motion/g1/dance1_subject2.npz
 ```
@@ -142,20 +142,20 @@ Choose an environment ID and one of its training configs from the built-in task 
 `TRAINING_CONFIG`:
 
 ```bash
-uv run scripts/train.py task=ENV_ID/TRAINING_CONFIG
+python scripts/train.py task=ENV_ID/TRAINING_CONFIG
 ```
 
 For example, train the G1 dance-tracking task with asynchronous FastSAC:
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance/motrix.fastsac algo.asynchronous=true
+python scripts/train.py task=g1-wbt-dance/motrix.fastsac algo.asynchronous=true
 ```
 
 The built-in configs use 2048 parallel environments and task-specific learning-iteration budgets. Use a small smoke test
 only to validate registry creation, tensor shapes, and the training entry point; it is not expected to produce a useful policy:
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance/motrix.fastsac \
+python scripts/train.py task=g1-wbt-dance/motrix.fastsac \
   algo.asynchronous=true num_envs=64 algo.trainer.num_learning_iterations=100
 ```
 
@@ -166,7 +166,7 @@ adaptive-sampling statistics are written to `info["metrics"]`. See [Task Environ
 ### Play the policy
 
 ```bash
-uv run scripts/play.py env=ENV_ID num_envs=16
+python scripts/play.py env=ENV_ID num_envs=16
 ```
 
 `play.py` selects the best policy from the latest metadata-backed run for the environment. The WBT play config starts at

--- a/docs/source/en/user_guide/envs/whole_body_tracking/motion_format.md
+++ b/docs/source/en/user_guide/envs/whole_body_tracking/motion_format.md
@@ -76,7 +76,7 @@ print(motion.body_names)
 target robot to check the floating-root layout, model joint set, and actual kinematics:
 
 ```bash
-uv run scripts/motion/replay.py --robot g1-29dof --motion /path/to/motion.npz
+python scripts/motion/replay.py --robot g1-29dof --motion /path/to/motion.npz
 ```
 
 Supported replay `--robot` values are `g1-29dof`, `dex-evt`, and `k1`.
@@ -86,13 +86,13 @@ Supported replay `--robot` values are `g1-29dof`, `dex-evt`, and `k1`.
 List available G1 clips:
 
 ```bash
-uv run scripts/motion/download_lafan.py --list
+python scripts/motion/download_lafan.py --list
 ```
 
 Download and convert one clip to 50 FPS:
 
 ```bash
-uv run scripts/motion/download_lafan.py \
+python scripts/motion/download_lafan.py \
   --motion dance1_subject1 \
   --output motrix_envs/src/motrix_envs/locomotion/wbt/assets/motion/g1/dance1_subject1.npz \
   --output-fps 50
@@ -101,7 +101,7 @@ uv run scripts/motion/download_lafan.py \
 You can also convert an existing G1 CSV:
 
 ```bash
-uv run scripts/motion/convert.py \
+python scripts/motion/convert.py \
   --from lafan \
   --input /path/to/dance1_subject1.csv \
   --output /path/to/dance1_subject1.npz \

--- a/docs/source/en/user_guide/getting_started/hello_motrixlab.md
+++ b/docs/source/en/user_guide/getting_started/hello_motrixlab.md
@@ -2,12 +2,14 @@
 
 This tutorial demonstrates the MotrixLab workflow through a simple example - loading and training a cartpole environment:
 
+Complete [installation](installation.md) first, then activate the environment with `source .venv/bin/activate` (Windows PowerShell: `.venv\Scripts\Activate.ps1`).
+
 ## Environment Preview
 
 We provide a simple script to visualize an environment without executing any training. This helps you verify that system dependencies are correctly configured:
 
 ```bash
-uv run scripts/view.py env=cartpole
+python scripts/view.py env=cartpole
 ```
 
 This will open a visualization window showing the cartpole physics simulation environment with random actions for demonstration.
@@ -17,7 +19,7 @@ This will open a visualization window showing the cartpole physics simulation en
 Start training the cartpole balancing task:
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
 ```
 
 The training process will automatically:
@@ -36,7 +38,7 @@ Training results will be saved in the `runs/cartpole/` directory, including:
 If you want to observe the model's learning process during training, you can enable visualization rendering:
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo render=true
+python scripts/train.py task=cartpole/skrl.ppo render=true
 ```
 
 ### 🎮 Interactive Rendering Control
@@ -56,7 +58,7 @@ This interactive control allows you to observe training effects when needed and 
 Use TensorBoard to view training progress:
 
 ```bash
-uv run tensorboard --logdir runs/cartpole
+tensorboard --logdir runs/cartpole
 ```
 
 ## Test Trained Model
@@ -65,10 +67,10 @@ After training is complete, test the trained policy:
 
 ```bash
 # Automatically find best policy for testing (recommended)
-uv run scripts/play.py env=cartpole
+python scripts/play.py env=cartpole
 
 # Manually specify a checkpoint from a metadata-backed run
-uv run scripts/play.py env=cartpole policy=/path/to/run/checkpoints/policy-file
+python scripts/play.py env=cartpole policy=/path/to/run/checkpoints/policy-file
 ```
 
 > **Tip**: The system automatically finds the latest run and its best policy under `runs/cartpole/`. A manually selected checkpoint must belong to a run containing `metadata.json` and `task_config.yaml`.

--- a/docs/source/en/user_guide/getting_started/installation.md
+++ b/docs/source/en/user_guide/getting_started/installation.md
@@ -41,40 +41,58 @@ git clone https://github.com/Motphys/MotrixLab.git
 cd MotrixLab
 ```
 
-### Configure Dependencies
+### Install the Runtime Environment
 
-Execute the following command to install complete dependencies:
-
-```bash
-# Install all dependencies
-uv sync --all-packages --all-groups --all-extras
-```
-
-If you only need specific training frameworks, you can selectively install to reduce dependency size:
+Install the runtime environment from the repository root (on Windows, run `install.ps1` in PowerShell; if the execution policy blocks it, use `powershell -ExecutionPolicy Bypass -File install.ps1`):
 
 ```bash
-
-# Install SKRL JAX (Linux only)
-uv sync --all-packages --extra skrl-jax
-
-# Install SKRL PyTorch
-uv sync --all-packages --extra skrl-torch
-
-# Install RSLRL (PyTorch only)
-uv sync --all-packages --extra rslrl
+sh install.sh
 ```
 
-## Package Boundaries
+This auto-detects your GPU vendor (NVIDIA → CUDA, AMD → ROCm) and installs all workspace packages,
+the matching PyTorch wheels, the SKRL training framework, and the built-in FastSAC algorithm.
 
--   `motrix-env-core` provides the environment framework without built-in tasks or assets.
--   `motrix-envs` depends on the core package and contains all built-in environments, robot models, and task data.
--   `motrix-rl` depends on the core package and does not require the built-in environments.
+### Activate the Environment
 
-In an external project, install only `motrix-env-core` when implementing custom environments. Install
-`motrix-envs` when using the built-in tasks. Importing `motrix_envs` performs built-in environment registration.
+After installing, activate the environment before running commands (Windows PowerShell:
+`.venv\Scripts\Activate.ps1`):
 
-```python
-from motrix_envs import registry
-from motrix_env_core.direct.env import DirectEnv
-from motrix_envs.core import EnvCfg, SceneCfg, configclass
+```bash
+source .venv/bin/activate
 ```
+
+```{note}
+Avoid bare `uv sync` / `uv run`: the CUDA and ROCm wheels are selected by mutually exclusive
+extras, so a bare command resolves the default PyPI fork and reinstalls the environment. Run
+commands from the activated environment, or pass `--no-sync` to one-off `uv run` calls.
+```
+
+## Development Environment
+
+The runtime environment only contains what training and deployment need. To contribute to the
+project (run tests, modify code, build the docs), install the full development environment:
+
+```bash
+sh install.sh --all
+```
+
+`--all` enables everything in one go: the dev toolchain, test dependencies, all training backends
+(`--skrl-jax` / `--rslrl`), and the docs tooling. You can also extend the runtime environment
+incrementally, e.g. `sh install.sh --docs` adds only the docs toolchain.
+
+## Option Reference
+
+Every mode installs all workspace packages; the runtime environment enables one GPU extra plus the
+training backend extra on top of them, and each option only selects or appends to that combination:
+
+| Option | Values | Description |
+| ------ | ------ | ----------- |
+| `--all` | — | Full development environment: everything below is enabled in one go (dev toolchain, test dependencies, all training backends, and docs tooling) |
+| *(none)* | — | Runtime environment; the GPU vendor is auto-detected (NVIDIA → CUDA, AMD → ROCm; CUDA as fallback when detection is impossible) |
+| `--gpu` | `cuda`<br>`rocm` | Select the torch wheel flavor explicitly, overriding auto-detection |
+| `--skrl-jax` | — | SKRL on JAX backend, Linux only |
+| `--rslrl` | — | RSL-RL on PyTorch backend |
+| `--docs` | — | Add the toolchain (sphinx) needed to build the documentation locally |
+| `-h`, `--help` | — | Show the help message |
+
+Run `sh install.sh --help` for the full option reference.

--- a/docs/source/en/user_guide/robots.md
+++ b/docs/source/en/user_guide/robots.md
@@ -137,8 +137,8 @@ zero-argument factory.
 Construct the config through the registry and preview it before using it in a task:
 
 ```bash
-uv run scripts/view.py robot=my-robot
-uv run pytest motrix_envs/tests/test_robot_cfg.py -q
+python scripts/view.py robot=my-robot
+python -m pytest motrix_envs/tests/test_robot_cfg.py -q
 ```
 
 At minimum, verify that the model builds, `base_link_name` exists, joints and actuators correspond, the default key
@@ -150,8 +150,8 @@ To include the robot in the generated table above, add its type and screenshot p
 `docs/scripts/generate_robot_docs.py`, then generate the screenshot and table:
 
 ```bash
-uv run docs/scripts/generate_robot_docs.py --screenshots my-robot
-uv run docs/scripts/generate_robot_docs.py --check
+python docs/scripts/generate_robot_docs.py --screenshots my-robot
+python docs/scripts/generate_robot_docs.py --check
 ```
 
 ## Preview a robot
@@ -159,7 +159,7 @@ uv run docs/scripts/generate_robot_docs.py --check
 Use `view.py` to inspect a registered robot in its default pose without creating an RL environment:
 
 ```bash
-uv run scripts/view.py robot=go2
+python scripts/view.py robot=go2
 ```
 
 Robot view mode builds a static standard scene. It does not sample actions or run a physics rollout.

--- a/docs/source/en/user_guide/tutorial/basic_frame.md
+++ b/docs/source/en/user_guide/tutorial/basic_frame.md
@@ -88,7 +88,7 @@ The trainer owns framework-specific model construction, optimization, checkpoint
 For example:
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo num_envs=1024
+python scripts/train.py task=cartpole/skrl.ppo num_envs=1024
 ```
 
 This command performs the following steps:
@@ -104,8 +104,8 @@ This command performs the following steps:
 The same environment can have multiple Task recipes without changing its implementation:
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
-uv run scripts/train.py task=cartpole/rslrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/rslrl.ppo
 ```
 
 SKRL supports JAX and Torch providers, RSLRL uses Torch, and `motrix.fastsac` selects its synchronous or asynchronous Torch trainer through `algo.asynchronous`. The selected Task and provider determine the algorithm configuration and output metadata.

--- a/docs/source/en/user_guide/tutorial/custom_training_backend.md
+++ b/docs/source/en/user_guide/tutorial/custom_training_backend.md
@@ -192,7 +192,7 @@ The Task's `rllib`, `algo`, and `train_backend` values must match the framework 
 If the backend is registered on the startup path, use the shared CLI:
 
 ```bash
-uv run scripts/train.py task=cartpole/myrl.ppo
+python scripts/train.py task=cartpole/myrl.ppo
 ```
 
 For an external experiment package, use its Hydra config root and import the backend registration module before entering the training function. No separate Python Task registry is required.

--- a/docs/source/en/user_guide/tutorial/export_onnx.md
+++ b/docs/source/en/user_guide/tutorial/export_onnx.md
@@ -18,17 +18,9 @@ SKRL/JAX checkpoints cannot be exported yet. The command accepts a complete run 
 
 ## Install Dependencies
 
-Install the ONNX dependencies and the backend used for training from the repository root:
-
-```bash
-# SKRL/Torch or Motrix FastSAC
-uv sync --all-packages --extra onnx --extra skrl-torch
-
-# RSL-RL
-uv sync --all-packages --extra onnx --extra rslrl
-```
-
-No additional step is needed if the environment was installed with `uv sync --all-packages --all-groups --all-extras`.
+No extra step is needed: the ONNX export and inference dependencies (`onnx`, `onnxruntime`) are part
+of the default runtime environment installed by `sh install.sh` (see
+[Installation](../getting_started/installation.md)).
 
 ## Export the Model
 
@@ -41,7 +33,7 @@ runs/cartpole/skrl/torch/ppo/<timestamp>/
 Export it to an explicit output path:
 
 ```bash
-uv run scripts/export_onnx.py \
+python scripts/export_onnx.py \
   run_dir=runs/cartpole/skrl/torch/ppo/<timestamp> \
   output=artifacts/cartpole.onnx
 ```
@@ -51,7 +43,7 @@ If a path contains spaces, quote the complete Hydra argument, for example `"run_
 When `output` is omitted, the model is written next to the best checkpoint as `policy.onnx`:
 
 ```bash
-uv run scripts/export_onnx.py \
+python scripts/export_onnx.py \
   run_dir=runs/cartpole/skrl/torch/ppo/<timestamp>
 ```
 
@@ -113,7 +105,7 @@ In most cases, only `run_dir` and `output` are needed. Override these Hydra para
 For example, export with opset 17 and more validation samples:
 
 ```bash
-uv run scripts/export_onnx.py \
+python scripts/export_onnx.py \
   run_dir=<run-dir> \
   output=policy.onnx \
   opset=17 \

--- a/docs/source/en/user_guide/tutorial/motrix_deploy.md
+++ b/docs/source/en/user_guide/tutorial/motrix_deploy.md
@@ -8,7 +8,7 @@ it on a real robot. If you already have a training run, start at “Export the a
 Run this command from the repository root:
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+sh install.sh --all
 ```
 
 This installs the training, MuJoCo, ONNX Runtime, and Unitree SDK2 dependencies.
@@ -18,7 +18,7 @@ This installs the training, MuJoCo, ONNX Runtime, and Unitree SDK2 dependencies.
 If you do not have a run yet, train the flat-terrain Go2 policy:
 
 ```bash
-uv run scripts/train.py task=go2-walk-flat/rslrl.ppo
+python scripts/train.py task=go2-walk-flat/rslrl.ppo
 ```
 
 Training results are saved under `runs/go2-walk-flat/`.
@@ -28,7 +28,7 @@ Training results are saved under `runs/go2-walk-flat/`.
 Export the latest run:
 
 ```bash
-uv run scripts/export_deploy.py env=go2-walk-flat
+python scripts/export_deploy.py env=go2-walk-flat
 ```
 
 The output is written to `artifacts/go2-walk-flat.deploy/`. This artifact is the only policy bundle needed for deployment;
@@ -37,7 +37,7 @@ it contains the model and its runtime configuration.
 ## 4. Inspect the artifact
 
 ```bash
-uv run motrix-deploy inspect \
+motrix-deploy inspect \
   artifact=artifacts/go2-walk-flat.deploy
 ```
 
@@ -46,7 +46,7 @@ Make sure the output reports `valid: true`.
 ## 5. Run Sim2Sim first
 
 ```bash
-uv run motrix-deploy sim2sim \
+motrix-deploy sim2sim \
   --config-name go2_walk_flat_sim2sim \
   artifact=artifacts/go2-walk-flat.deploy
 ```
@@ -60,10 +60,10 @@ Put the robot in low-level/debug mode, connect Ethernet, and keep an emergency s
 actual network interface:
 
 ```bash
-uv run motrix-deploy inspect \
+motrix-deploy inspect \
   artifact=artifacts/go2-walk-flat.deploy
 
-uv run motrix-deploy sim2real \
+motrix-deploy sim2real \
   --config-name go2_walk_flat_sim2real \
   artifact=artifacts/go2-walk-flat.deploy \
   backend.network_interface=enp5s0 \
@@ -76,7 +76,7 @@ to send motion commands. Press B to enter the lie-down sequence; Select triggers
 You can also inspect the robot state before sending policy commands:
 
 ```bash
-uv run python -m motrix_deploy_unitree.read_lowstate enp5s0
+python -m motrix_deploy_unitree.read_lowstate enp5s0
 ```
 
 ## Advanced usage
@@ -88,7 +88,7 @@ The physical-runtime base configuration, `configs/deploy/sim2real/base.yaml`, cu
 gains, or pass 12 non-negative values on the command line:
 
 ```bash
-uv run motrix-deploy sim2real \
+motrix-deploy sim2real \
   artifact=artifacts/go2-walk-flat.deploy \
   backend.network_interface=enp5s0 \
   'backend.kp=[20,25,30,20,25,30,22,27,32,22,27,32]' \
@@ -101,7 +101,7 @@ uv run motrix-deploy sim2real \
 Run the read-only diagnostic before sending any motion command:
 
 ```bash
-uv run python -m motrix_deploy_unitree.read_lowstate enp5s0
+python -m motrix_deploy_unitree.read_lowstate enp5s0
 ```
 
 ### Send a single-joint motion command
@@ -111,7 +111,7 @@ To bypass the policy and debug a single joint-position motion, use the bounded h
 does not require a training run, checkpoint, policy, or deployment artifact:
 
 ```bash
-uv run python -m motrix_deploy_unitree.go2_joint_control \
+python -m motrix_deploy_unitree.go2_joint_control \
   enp5s0 \
   FL_thigh_joint \
   0.9 \

--- a/docs/source/en/user_guide/tutorial/runs_and_checkpoints.md
+++ b/docs/source/en/user_guide/tutorial/runs_and_checkpoints.md
@@ -106,16 +106,16 @@ The actual checkpoint files live under the `checkpoints/` subdirectory, and `man
 
     ```bash
     # Auto-discover and play the best policy of the latest run
-    uv run scripts/play.py env=g1-walk-flat
+    python scripts/play.py env=g1-walk-flat
 
     # Specify a checkpoint (must be able to locate metadata.json above it)
-    uv run scripts/play.py env=g1-walk-flat policy=/path/to/run/checkpoints/latest.pt
+    python scripts/play.py env=g1-walk-flat policy=/path/to/run/checkpoints/latest.pt
     ```
 
 -   **Resume**: set `resume=` to a run directory or checkpoint path, and the framework resolves `latest_training_state` from it to continue training.
 
     ```bash
-    uv run scripts/train.py task=g1-walk-flat/motrix.fastsac \
+    python scripts/train.py task=g1-walk-flat/motrix.fastsac \
       resume=/path/to/run
     ```
 
@@ -124,5 +124,5 @@ The actual checkpoint files live under the `checkpoints/` subdirectory, and `man
 TensorBoard logs (`events.out.tfevents.*`) are written directly under the run root and can be viewed per environment:
 
 ```bash
-uv run tensorboard --logdir runs/g1-walk-flat
+tensorboard --logdir runs/g1-walk-flat
 ```

--- a/docs/source/en/user_guide/tutorial/training_and_result.md
+++ b/docs/source/en/user_guide/tutorial/training_and_result.md
@@ -10,12 +10,12 @@ The training entry point uses Hydra's `task=<environment>/<framework>.<algorithm
 
 ```bash
 # Train the default Cartpole SKRL PPO Task
-uv run scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
 
 # Select another framework or algorithm
-uv run scripts/train.py task=cartpole/rslrl.ppo
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac algo.asynchronous=false
+python scripts/train.py task=cartpole/rslrl.ppo
+python scripts/train.py task=g1-walk-flat/motrix.fastsac
+python scripts/train.py task=g1-walk-flat/motrix.fastsac algo.asynchronous=false
 ```
 
 Built-in RL methods and their training backends:
@@ -26,28 +26,28 @@ Built-in RL methods and their training backends:
 | `rslrl.ppo`      | `torch`          | RSLRL PPO                                                   |
 | `motrix.fastsac` | `torch`          | FastSAC; `algo.asynchronous` selects the execution topology |
 
-Run `uv run scripts/train.py --help` to list the Tasks available in the current checkout. See [Task Configuration and CLI Overrides](training_environment_config.md) for the Task file layout and override rules.
+Run `python scripts/train.py --help` to list the Tasks available in the current checkout. See [Task Configuration and CLI Overrides](training_environment_config.md) for the Task file layout and override rules.
 
 ### Selecting Training and Simulation Backends
 
 ```bash
 # Override the training backend (auto-selected when task.train_backend is null)
-uv run scripts/train.py task=cartpole/skrl.ppo task.train_backend=jax
-uv run scripts/train.py task=cartpole/skrl.ppo task.train_backend=torch
+python scripts/train.py task=cartpole/skrl.ppo task.train_backend=jax
+python scripts/train.py task=cartpole/skrl.ppo task.train_backend=torch
 
 # Specify the simulator injected into manager-based environments
-uv run scripts/train.py task=g1-wbt-dance sim=motrixsim
+python scripts/train.py task=g1-wbt-dance sim=motrixsim
 ```
 
 ### Training Scale and Random Seed
 
 ```bash
 # Number of parallel environments
-uv run scripts/train.py task=cartpole/skrl.ppo num_envs=1024
+python scripts/train.py task=cartpole/skrl.ppo num_envs=1024
 
 # Fixed random seed (reproducible) / choose a random seed at runtime
-uv run scripts/train.py task=cartpole/skrl.ppo seed=42
-uv run scripts/train.py task=cartpole/skrl.ppo seed=null
+python scripts/train.py task=cartpole/skrl.ppo seed=42
+python scripts/train.py task=cartpole/skrl.ppo seed=null
 ```
 
 ```{note}
@@ -58,14 +58,14 @@ Hydra can override typed algorithm fields directly. For example: `algo.agent.lea
 
 ```bash
 # After training finishes successfully, play the best policy of this run
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac play=true
+python scripts/train.py task=g1-walk-flat/motrix.fastsac play=true
 
 # Resume from a run directory or a checkpoint
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac \
+python scripts/train.py task=g1-walk-flat/motrix.fastsac \
   resume=/path/to/run
 
 # Enable rendering to monitor the training process
-uv run scripts/train.py task=cartpole/skrl.ppo render=true
+python scripts/train.py task=cartpole/skrl.ppo render=true
 ```
 
 ### Common Hydra Overrides
@@ -92,7 +92,7 @@ uv run scripts/train.py task=cartpole/skrl.ppo render=true
 TensorBoard logs are written under the run directory and can be viewed per environment:
 
 ```bash
-uv run tensorboard --logdir runs/cartpole
+tensorboard --logdir runs/cartpole
 ```
 
 Besides the standard return and loss curves, if an environment exposes per-term rewards via `info["Reward"]`, they are also logged to TensorBoard during training.
@@ -103,14 +103,14 @@ Playback (play) does not require re-specifying the RL method — the correct `rl
 
 ```bash
 # Auto-discover and play the best policy of the latest run (recommended)
-uv run scripts/play.py env=cartpole
+python scripts/play.py env=cartpole
 
 # Specify a checkpoint (must be able to locate metadata.json above it)
-uv run scripts/play.py env=g1-walk-flat \
+python scripts/play.py env=g1-walk-flat \
   policy=/path/to/run/checkpoints/latest.pt
 
 # Specify the number of playback environments
-uv run scripts/play.py env=cartpole num_envs=100
+python scripts/play.py env=cartpole num_envs=100
 ```
 
 ```{note}

--- a/docs/source/en/user_guide/tutorial/training_environment_config.md
+++ b/docs/source/en/user_guide/tutorial/training_environment_config.md
@@ -65,19 +65,19 @@ A Task only needs to contain values that differ from the algorithm base. It does
 Print the fully composed Hydra configuration before starting training:
 
 ```bash
-uv run scripts/train.py --cfg job --resolve task=my-robot/skrl.ppo
+python scripts/train.py --cfg job --resolve task=my-robot/skrl.ppo
 ```
 
 This command does not start training. After verifying `task.env`, `num_envs`, and `algo.trainer.timesteps`, start the run:
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo
+python scripts/train.py task=my-robot/skrl.ppo
 ```
 
 List all Tasks available in the repository with:
 
 ```bash
-uv run scripts/train.py --help
+python scripts/train.py --help
 ```
 
 ## Adjust Task runtime settings
@@ -191,7 +191,7 @@ The MotrixLab CLI uses Hydra's `key=value` syntax. CLI values apply only to the 
 ### Override runtime settings
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=my-robot/skrl.ppo \
   num_envs=64 \
   seed=7 \
@@ -202,7 +202,7 @@ uv run scripts/train.py \
 Enable training rendering and play the policy afterward:
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo render=true play=true
+python scripts/train.py task=my-robot/skrl.ppo render=true play=true
 ```
 
 ### Override algorithm settings
@@ -210,7 +210,7 @@ uv run scripts/train.py task=my-robot/skrl.ppo render=true play=true
 SKRL PPO:
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=my-robot/skrl.ppo \
   algo.agent.learning_rate=5e-4 \
   algo.agent.learning_epochs=8 \
@@ -220,7 +220,7 @@ uv run scripts/train.py \
 RSLRL PPO:
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=cartpole/rslrl.ppo \
   algo.algorithm.learning_rate=5e-4 \
   algo.algorithm.entropy_coef=0.005 \
@@ -230,7 +230,7 @@ uv run scripts/train.py \
 FastSAC:
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=g1-walk-flat/motrix.fastsac \
   algo.asynchronous=true \
   algo.agent.actor_learning_rate=1e-4 \
@@ -244,20 +244,20 @@ uv run scripts/train.py \
 Use lowercase `true` and `false` for booleans:
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo render=true
+python scripts/train.py task=my-robot/skrl.ppo render=true
 ```
 
 Use `null` to clear nullable fields:
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo seed=null
-uv run scripts/train.py task=my-robot/skrl.ppo algo.agent.learning_rate_scheduler=null
+python scripts/train.py task=my-robot/skrl.ppo seed=null
+python scripts/train.py task=my-robot/skrl.ppo algo.agent.learning_rate_scheduler=null
 ```
 
 Quote lists so the shell does not interpret brackets:
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=my-robot/skrl.ppo \
   'algo.models.policy.hiddens=[128,64]' \
   'algo.models.value.hiddens=[128,64]'
@@ -274,7 +274,7 @@ Training uses structured schemas. Existing fields do not need a `+` prefix. Add 
 Combine CLI overrides with `--cfg job --resolve` to inspect the exact values that would be used:
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   --cfg job \
   --resolve \
   task=my-robot/skrl.ppo \
@@ -316,13 +316,13 @@ algo:
 Train with the JAX delta:
 
 ```bash
-uv run scripts/train.py task=go2-walk-flat/skrl.ppo.jax
+python scripts/train.py task=go2-walk-flat/skrl.ppo.jax
 ```
 
 Overriding the backend directly also selects the JAX trainer:
 
 ```bash
-uv run scripts/train.py task=go2-walk-flat/skrl.ppo task.train_backend=jax
+python scripts/train.py task=go2-walk-flat/skrl.ppo task.train_backend=jax
 ```
 
 This form does not load backend-specific values from `skrl.ppo.jax.yaml`. Select the `.jax` or `.torch` Task directly when a backend delta exists.
@@ -413,15 +413,15 @@ Hydra validates field names and types against the structured schema registered b
 `scripts/play.py` and `scripts/view.py` use the same `key=value` syntax:
 
 ```bash
-uv run scripts/view.py env=cartpole num_envs=4
-uv run scripts/play.py env=cartpole num_envs=1
-uv run scripts/play.py policy=/path/to/checkpoint.pt num_envs=1
+python scripts/view.py env=cartpole num_envs=4
+python scripts/play.py env=cartpole num_envs=1
+python scripts/play.py policy=/path/to/checkpoint.pt num_envs=1
 ```
 
 Play loads the `task_config.yaml` stored with a training run. To temporarily override algorithm settings, use `rl` as the algorithm root. Since `rl` starts as an empty mapping, add the path with `+`:
 
 ```bash
-uv run scripts/play.py \
+python scripts/play.py \
   env=cartpole \
   '+rl.agent.learning_rate=1e-4'
 ```

--- a/docs/source/zh_CN/user_guide/envs/basic/acrobot.md
+++ b/docs/source/zh_CN/user_guide/envs/basic/acrobot.md
@@ -63,36 +63,36 @@ Acrobot 是一个双连杆摆动和平衡任务。目标是使用一个电机扭
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=acrobot
+python scripts/view.py env=acrobot
 ```
 
 ### 2. 开始训练
 
 ```bash
 # 使用默认参数训练
-uv run scripts/train.py task=acrobot/skrl.ppo
+python scripts/train.py task=acrobot/skrl.ppo
 
 # 自定义并行环境数
-uv run scripts/train.py task=acrobot/skrl.ppo num_envs=1024
+python scripts/train.py task=acrobot/skrl.ppo num_envs=1024
 
 # 开启训练时渲染
-uv run scripts/train.py task=acrobot/skrl.ppo render=true
+python scripts/train.py task=acrobot/skrl.ppo render=true
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/acrobot
+tensorboard --logdir runs/acrobot
 ```
 
 ### 4. 测试训练结果
 
 ```bash
 # 自动发现最佳策略（推荐）
-uv run scripts/play.py env=acrobot
+python scripts/play.py env=acrobot
 
 # 手动指定带 metadata 的 run 中的 checkpoint
-uv run scripts/play.py env=acrobot policy=/path/to/run/checkpoints/policy-file
+python scripts/play.py env=acrobot policy=/path/to/run/checkpoints/policy-file
 ```
 
 > **提示**：策略会从 `runs/acrobot/` 中自动选择。使用 `policy=...` 时，checkpoint 所属 run 必须包含 `metadata.json`。

--- a/docs/source/zh_CN/user_guide/envs/basic/cartpole.md
+++ b/docs/source/zh_CN/user_guide/envs/basic/cartpole.md
@@ -88,25 +88,25 @@ reward = 1.0  # 每步固定奖励
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=cartpole
+python scripts/view.py env=cartpole
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/cartpole
+tensorboard --logdir runs/cartpole
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=cartpole
+python scripts/play.py env=cartpole
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/basic/pendulum.md
+++ b/docs/source/zh_CN/user_guide/envs/basic/pendulum.md
@@ -64,36 +64,36 @@
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=pendulum
+python scripts/view.py env=pendulum
 ```
 
 ### 2. 开始训练
 
 ```bash
 # 默认参数训练
-uv run scripts/train.py task=pendulum/skrl.ppo
+python scripts/train.py task=pendulum/skrl.ppo
 
 # 自定义并行环境数
-uv run scripts/train.py task=pendulum/skrl.ppo num_envs=1024
+python scripts/train.py task=pendulum/skrl.ppo num_envs=1024
 
 # 开启训练时渲染
-uv run scripts/train.py task=pendulum/skrl.ppo render=true
+python scripts/train.py task=pendulum/skrl.ppo render=true
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/pendulum
+tensorboard --logdir runs/pendulum
 ```
 
 ### 4. 测试训练结果
 
 ```bash
 # 自动寻找最新/最优策略（推荐）
-uv run scripts/play.py env=pendulum
+python scripts/play.py env=pendulum
 
 # 手动指定带 metadata 的 run 中的 checkpoint
-uv run scripts/play.py env=pendulum policy=/path/to/run/checkpoints/policy-file
+python scripts/play.py env=pendulum policy=/path/to/run/checkpoints/policy-file
 ```
 
 > **提示**：策略默认在 `runs/pendulum/` 下自动发现。使用 `policy=...` 时，checkpoint 所属 run 必须包含 `metadata.json`。

--- a/docs/source/zh_CN/user_guide/envs/basic/stewart.md
+++ b/docs/source/zh_CN/user_guide/envs/basic/stewart.md
@@ -156,15 +156,15 @@ reward = fall_penalty if fallen else reward
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=stewart-static
-uv run scripts/view.py env=stewart-disturb-xy
+python scripts/view.py env=stewart-static
+python scripts/view.py env=stewart-disturb-xy
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=stewart-static/skrl.ppo
-uv run scripts/train.py task=stewart-disturb-xy/skrl.ppo
+python scripts/train.py task=stewart-static/skrl.ppo
+python scripts/train.py task=stewart-disturb-xy/skrl.ppo
 ```
 
 ### 训练说明
@@ -176,15 +176,15 @@ uv run scripts/train.py task=stewart-disturb-xy/skrl.ppo
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/stewart-static
-uv run tensorboard --logdir runs/stewart-disturb-xy
+tensorboard --logdir runs/stewart-static
+tensorboard --logdir runs/stewart-disturb-xy
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=stewart-static
-uv run scripts/play.py env=stewart-disturb-xy
+python scripts/play.py env=stewart-static
+python scripts/play.py env=stewart-disturb-xy
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/bring_ball.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/bring_ball.md
@@ -137,7 +137,7 @@ penalty_side + penalty_hover
 ### 1. 环境预览（随机动作）
 
 ```bash
-uv run scripts/view.py env=dm-manipulator-bring-ball
+python scripts/view.py env=dm-manipulator-bring-ball
 ```
 
 ### 2. 开始训练
@@ -145,19 +145,19 @@ uv run scripts/view.py env=dm-manipulator-bring-ball
 建议显式指定训练后端（JAX / PyTorch 二选一）：
 
 ```bash
-uv run scripts/train.py task=dm-manipulator-bring-ball/skrl.ppo.torch
+python scripts/train.py task=dm-manipulator-bring-ball/skrl.ppo.torch
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-manipulator-bring-ball
+tensorboard --logdir runs/dm-manipulator-bring-ball
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-manipulator-bring-ball
+python scripts/play.py env=dm-manipulator-bring-ball
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_cheetah.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_cheetah.md
@@ -102,25 +102,25 @@ cheetah 的奖励函数由以下几个部分组成：
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=dm-cheetah
+python scripts/view.py env=dm-cheetah
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=dm-cheetah/skrl.ppo
+python scripts/train.py task=dm-cheetah/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-cheetah
+tensorboard --logdir runs/dm-cheetah
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-cheetah
+python scripts/play.py env=dm-cheetah
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_finger.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_finger.md
@@ -143,15 +143,15 @@ Turn 的核心是 tip 触达并对准目标点：目标点位于 spinner 周围�
 ### 1. 环境预览（随机动作）
 
 ```bash
-uv run scripts/view.py env=dm-finger-spin
+python scripts/view.py env=dm-finger-spin
 ```
 
 ```bash
-uv run scripts/view.py env=dm-finger-turn-easy
+python scripts/view.py env=dm-finger-turn-easy
 ```
 
 ```bash
-uv run scripts/view.py env=dm-finger-turn-hard
+python scripts/view.py env=dm-finger-turn-hard
 ```
 
 ### 2. 开始训练
@@ -159,21 +159,21 @@ uv run scripts/view.py env=dm-finger-turn-hard
 建议显式指定训练后端（JAX / PyTorch 二选一）：
 
 ```bash
-uv run scripts/train.py task=dm-finger-spin/skrl.ppo task.train_backend=torch
+python scripts/train.py task=dm-finger-spin/skrl.ppo task.train_backend=torch
 ```
 
 ```bash
-uv run scripts/train.py task=dm-finger-turn-easy/skrl.ppo task.train_backend=torch
+python scripts/train.py task=dm-finger-turn-easy/skrl.ppo task.train_backend=torch
 ```
 
 ```bash
-uv run scripts/train.py task=dm-finger-turn-hard/skrl.ppo task.train_backend=torch
+python scripts/train.py task=dm-finger-turn-hard/skrl.ppo task.train_backend=torch
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-finger-spin
+tensorboard --logdir runs/dm-finger-spin
 ```
 
 ### 4. 测试训练结果
@@ -181,7 +181,7 @@ uv run tensorboard --logdir runs/dm-finger-spin
 `scripts/play.py` 默认会在 `runs/{env-name}/` 下查找最新的 metadata-backed run，并加载其 `best_policy` artifact；也可以用 `policy=...` 显式指定 checkpoint：
 
 ```bash
-uv run scripts/play.py env=dm-finger-turn-hard
+python scripts/play.py env=dm-finger-turn-hard
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_hopper.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_hopper.md
@@ -109,28 +109,28 @@ hopper 的奖励函数由以下几个部分组成：
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=dm-hopper-stand
-uv run scripts/view.py env=dm-hopper-hop
+python scripts/view.py env=dm-hopper-stand
+python scripts/view.py env=dm-hopper-hop
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=dm-hopper-stand/skrl.ppo
-uv run scripts/train.py task=dm-hopper-hop/skrl.ppo
+python scripts/train.py task=dm-hopper-stand/skrl.ppo
+python scripts/train.py task=dm-hopper-hop/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-hopper-hop
+tensorboard --logdir runs/dm-hopper-hop
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-hopper-stand
-uv run scripts/play.py env=dm-hopper-hop
+python scripts/play.py env=dm-hopper-stand
+python scripts/play.py env=dm-hopper-hop
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_humanoid.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_humanoid.md
@@ -185,31 +185,31 @@ total_reward = posture_reward * speed_reward * energy_reward * gait_reward
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=dm-humanoid-stand
-uv run scripts/view.py env=dm-humanoid-walk
-uv run scripts/view.py env=dm-humanoid-run
+python scripts/view.py env=dm-humanoid-stand
+python scripts/view.py env=dm-humanoid-walk
+python scripts/view.py env=dm-humanoid-run
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=dm-humanoid-stand/skrl.ppo
-uv run scripts/train.py task=dm-humanoid-walk/skrl.ppo
-uv run scripts/train.py task=dm-humanoid-run/skrl.ppo
+python scripts/train.py task=dm-humanoid-stand/skrl.ppo
+python scripts/train.py task=dm-humanoid-walk/skrl.ppo
+python scripts/train.py task=dm-humanoid-run/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-humanoid-walk
+tensorboard --logdir runs/dm-humanoid-walk
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-humanoid-stand
-uv run scripts/play.py env=dm-humanoid-walk
-uv run scripts/play.py env=dm-humanoid-run
+python scripts/play.py env=dm-humanoid-stand
+python scripts/play.py env=dm-humanoid-walk
+python scripts/play.py env=dm-humanoid-run
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_lqr.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_lqr.md
@@ -157,29 +157,29 @@ reward -= out_of_bounds_penalty
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=dm-lqr-2-1
-uv run scripts/view.py env=dm-lqr-6-2
+python scripts/view.py env=dm-lqr-2-1
+python scripts/view.py env=dm-lqr-6-2
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=dm-lqr-2-1/skrl.ppo
-uv run scripts/train.py task=dm-lqr-6-2/skrl.ppo
+python scripts/train.py task=dm-lqr-2-1/skrl.ppo
+python scripts/train.py task=dm-lqr-6-2/skrl.ppo
 ```
 
 ### 3. 查看训练曲线
 
 ```bash
-uv run tensorboard --logdir runs/dm-lqr-2-1
-uv run tensorboard --logdir runs/dm-lqr-6-2
+tensorboard --logdir runs/dm-lqr-2-1
+tensorboard --logdir runs/dm-lqr-6-2
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-lqr-2-1
-uv run scripts/play.py env=dm-lqr-6-2
+python scripts/play.py env=dm-lqr-2-1
+python scripts/play.py env=dm-lqr-6-2
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_point_mass.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_point_mass.md
@@ -115,25 +115,25 @@ rwd = distance_reward + target_bonus + continuous_reward + path_reward - center_
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=point_mass
+python scripts/view.py env=point_mass
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=point_mass/skrl.ppo
+python scripts/train.py task=point_mass/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/point_mass
+tensorboard --logdir runs/point_mass
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=point_mass
+python scripts/play.py env=point_mass
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_quadruped.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_quadruped.md
@@ -228,37 +228,37 @@ total_reward = stage_terms + ready_terms + push_terms - penalty_terms
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=dm-quadruped-walk
-uv run scripts/view.py env=dm-quadruped-run
-uv run scripts/view.py env=dm-quadruped-escape
-uv run scripts/view.py env=dm-quadruped-fetch
+python scripts/view.py env=dm-quadruped-walk
+python scripts/view.py env=dm-quadruped-run
+python scripts/view.py env=dm-quadruped-escape
+python scripts/view.py env=dm-quadruped-fetch
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=dm-quadruped-walk/skrl.ppo
-uv run scripts/train.py task=dm-quadruped-run/skrl.ppo
-uv run scripts/train.py task=dm-quadruped-escape/skrl.ppo
-uv run scripts/train.py task=dm-quadruped-fetch/skrl.ppo
+python scripts/train.py task=dm-quadruped-walk/skrl.ppo
+python scripts/train.py task=dm-quadruped-run/skrl.ppo
+python scripts/train.py task=dm-quadruped-escape/skrl.ppo
+python scripts/train.py task=dm-quadruped-fetch/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-quadruped-walk
-uv run tensorboard --logdir runs/dm-quadruped-run
-uv run tensorboard --logdir runs/dm-quadruped-escape
-uv run tensorboard --logdir runs/dm-quadruped-fetch
+tensorboard --logdir runs/dm-quadruped-walk
+tensorboard --logdir runs/dm-quadruped-run
+tensorboard --logdir runs/dm-quadruped-escape
+tensorboard --logdir runs/dm-quadruped-fetch
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-quadruped-walk
-uv run scripts/play.py env=dm-quadruped-run
-uv run scripts/play.py env=dm-quadruped-escape
-uv run scripts/play.py env=dm-quadruped-fetch
+python scripts/play.py env=dm-quadruped-walk
+python scripts/play.py env=dm-quadruped-run
+python scripts/play.py env=dm-quadruped-escape
+python scripts/play.py env=dm-quadruped-fetch
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_reacher.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_reacher.md
@@ -93,25 +93,25 @@ reward = tolerance(|| fingertip - target ||)
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=dm-reacher
+python scripts/view.py env=dm-reacher
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=dm-reacher/skrl.ppo
+python scripts/train.py task=dm-reacher/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-reacher
+tensorboard --logdir runs/dm-reacher
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-reacher
+python scripts/play.py env=dm-reacher
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/dm_control/dm_walker.md
+++ b/docs/source/zh_CN/user_guide/envs/dm_control/dm_walker.md
@@ -94,31 +94,31 @@ walker 的奖励函数由以下几个部分组成：
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=dm-stander
-uv run scripts/view.py env=dm-walker
-uv run scripts/view.py env=dm-runner
+python scripts/view.py env=dm-stander
+python scripts/view.py env=dm-walker
+python scripts/view.py env=dm-runner
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=dm-stander/skrl.ppo
-uv run scripts/train.py task=dm-walker/skrl.ppo
-uv run scripts/train.py task=dm-runner/skrl.ppo
+python scripts/train.py task=dm-stander/skrl.ppo
+python scripts/train.py task=dm-walker/skrl.ppo
+python scripts/train.py task=dm-runner/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/dm-walker
+tensorboard --logdir runs/dm-walker
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=dm-stander
-uv run scripts/play.py env=dm-walker
-uv run scripts/play.py env=dm-runner
+python scripts/play.py env=dm-stander
+python scripts/play.py env=dm-walker
+python scripts/play.py env=dm-runner
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/humanoid_velocity_tracking.md
+++ b/docs/source/zh_CN/user_guide/envs/humanoid_velocity_tracking.md
@@ -90,15 +90,15 @@ MotrixLab 已为下列机器人提供平地和程序化起伏高度场配置。�
 从“内置机器人”表格中选择 Env ID 和对应的训练配置，并替换下列命令中的 `ENV_ID` 与 `TRAINING_CONFIG`：
 
 ```bash
-uv run scripts/view.py env=ENV_ID num_envs=1
-uv run scripts/train.py task=ENV_ID/TRAINING_CONFIG
-uv run scripts/play.py env=ENV_ID num_envs=16
+python scripts/view.py env=ENV_ID num_envs=1
+python scripts/train.py task=ENV_ID/TRAINING_CONFIG
+python scripts/play.py env=ENV_ID num_envs=16
 ```
 
 例如，使用 FastSAC 异步训练 K1 起伏地形任务：
 
 ```bash
-uv run scripts/train.py task=k1-walk-rough/motrix.fastsac algo.asynchronous=true
+python scripts/train.py task=k1-walk-rough/motrix.fastsac algo.asynchronous=true
 ```
 
 `view.py` 使用随机动作，仅用于检查场景和模型；训练后的步态需要通过 `play.py` 回放策略查看。

--- a/docs/source/zh_CN/user_guide/envs/humanoid_velocity_tracking/adding_robot.md
+++ b/docs/source/zh_CN/user_guide/envs/humanoid_velocity_tracking/adding_robot.md
@@ -114,7 +114,7 @@ asset = AssetCfg(
 建议先运行机器人预览命令检查关节顺序、默认姿态、PD 参数、脚底 site 和碰撞体名称：
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
+python scripts/view.py robot=<robot-config-id>
 ```
 
 ## 4. 注册环境实现
@@ -156,13 +156,13 @@ algo:
 建议按以下顺序验证：
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
-uv run scripts/view.py env=<robot>-walk-flat
-uv run scripts/view.py env=<robot>-walk-terrain
-uv run scripts/train.py task=<robot>-walk-flat/motrix.fastsac
-uv run scripts/train.py task=<robot>-walk-flat/motrix.fastsac algo.asynchronous=false
-uv run pytest motrix_envs/tests/test_humanoid_walk.py -q
-uv run pytest motrix_rl/tests/test_task_configs.py -q
+python scripts/view.py robot=<robot-config-id>
+python scripts/view.py env=<robot>-walk-flat
+python scripts/view.py env=<robot>-walk-terrain
+python scripts/train.py task=<robot>-walk-flat/motrix.fastsac
+python scripts/train.py task=<robot>-walk-flat/motrix.fastsac algo.asynchronous=false
+python -m pytest motrix_envs/tests/test_humanoid_walk.py -q
+python -m pytest motrix_rl/tests/test_task_configs.py -q
 ```
 
 预览阶段重点检查默认姿态、脚底高度、地面碰撞、动作方向和起伏地形出生位置。新增内置环境配置时，还应在共享人形环境

--- a/docs/source/zh_CN/user_guide/envs/index.md
+++ b/docs/source/zh_CN/user_guide/envs/index.md
@@ -5,7 +5,7 @@ MotrixLab Environment 定义可通过 Env Registry 创建的仿真任务，包�
 使用以下命令可以在不启动训练的情况下预览一个环境：
 
 ```bash
-uv run scripts/view.py env=<env-id>
+python scripts/view.py env=<env-id>
 ```
 
 ## 环境主题

--- a/docs/source/zh_CN/user_guide/envs/manipulation/bounce_ball.md
+++ b/docs/source/zh_CN/user_guide/envs/manipulation/bounce_ball.md
@@ -411,25 +411,25 @@ $$
 ### 1. 环境预览
 
 ```bash
-uv run scripts/view.py env=bounce_ball
+python scripts/view.py env=bounce_ball
 ```
 
 ### 2. 开始训练
 
 ```bash
-uv run scripts/train.py task=bounce_ball/skrl.ppo
+python scripts/train.py task=bounce_ball/skrl.ppo
 ```
 
 ### 3. 查看训练进度
 
 ```bash
-uv run tensorboard --logdir runs/bounce_ball
+tensorboard --logdir runs/bounce_ball
 ```
 
 ### 4. 测试训练结果
 
 ```bash
-uv run scripts/play.py env=bounce_ball
+python scripts/play.py env=bounce_ball
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/manipulation/franka_lift_cube.md
+++ b/docs/source/zh_CN/user_guide/envs/manipulation/franka_lift_cube.md
@@ -239,17 +239,17 @@ p = 1 / (1 + exp(-action))
 ### 训练
 
 ```bash
-uv run scripts/train.py task=franka-lift-cube/skrl.ppo
+python scripts/train.py task=franka-lift-cube/skrl.ppo
 ```
 
 ### 策略评估
 
 ```bash
-uv run scripts/play.py env=franka-lift-cube
+python scripts/play.py env=franka-lift-cube
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/franka-lift-cube
+tensorboard --logdir runs/franka-lift-cube
 ```

--- a/docs/source/zh_CN/user_guide/envs/manipulation/franka_open_cabinet.md
+++ b/docs/source/zh_CN/user_guide/envs/manipulation/franka_open_cabinet.md
@@ -234,17 +234,17 @@ Franka Emika Panda 是一个 7 自由度机械臂，由以下主要部分组成�
 ### 训练
 
 ```bash
-uv run scripts/train.py task=franka-open-cabinet/skrl.ppo
+python scripts/train.py task=franka-open-cabinet/skrl.ppo
 ```
 
 ### 策略评估
 
 ```bash
-uv run scripts/play.py env=franka-open-cabinet
+python scripts/play.py env=franka-open-cabinet
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/franka-open-cabinet
+tensorboard --logdir runs/franka-open-cabinet
 ```

--- a/docs/source/zh_CN/user_guide/envs/manipulation/rm65_insert_peg.md
+++ b/docs/source/zh_CN/user_guide/envs/manipulation/rm65_insert_peg.md
@@ -269,17 +269,17 @@ RM65 机器人在该环境中包含以下主要部分：
 ### 训练
 
 ```bash
-uv run scripts/train.py task=rm65_insert_peg/motrix.fastsac
+python scripts/train.py task=rm65_insert_peg/motrix.fastsac
 ```
 
 ### 策略评估
 
 ```bash
-uv run scripts/play.py env=rm65_insert_peg num_envs=16
+python scripts/play.py env=rm65_insert_peg num_envs=16
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/rm65_insert_peg/fastsac
+tensorboard --logdir runs/rm65_insert_peg/fastsac
 ```

--- a/docs/source/zh_CN/user_guide/envs/manipulation/rm65_open_cabinet.md
+++ b/docs/source/zh_CN/user_guide/envs/manipulation/rm65_open_cabinet.md
@@ -242,17 +242,17 @@ RM65 机器人在该环境中包含以下主要部分：
 ### 训练
 
 ```bash
-uv run scripts/train.py task=rm65-open-cabinet/skrl.ppo task.train_backend=torch
+python scripts/train.py task=rm65-open-cabinet/skrl.ppo task.train_backend=torch
 ```
 
 ### 策略评估
 
 ```bash
-uv run scripts/play.py env=rm65-open-cabinet
+python scripts/play.py env=rm65-open-cabinet
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/rm65_open_cabinet
+tensorboard --logdir runs/rm65_open_cabinet
 ```

--- a/docs/source/zh_CN/user_guide/envs/manipulation/shadow_hand_repose.md
+++ b/docs/source/zh_CN/user_guide/envs/manipulation/shadow_hand_repose.md
@@ -297,25 +297,25 @@ actuator_ctrls = targets
 ### 训练
 
 ```bash
-uv run scripts/train.py task=shadow-hand-repose/skrl.ppo
+python scripts/train.py task=shadow-hand-repose/skrl.ppo
 ```
 
 ### 策略评估
 
 ```bash
-uv run scripts/play.py env=shadow-hand-repose
+python scripts/play.py env=shadow-hand-repose
 ```
 
 ### 环境可视化
 
 ```bash
-uv run scripts/view.py env=shadow-hand-repose
+python scripts/view.py env=shadow-hand-repose
 ```
 
 ### TensorBoard
 
 ```bash
-uv run tensorboard --logdir runs/shadow-hand-repose
+tensorboard --logdir runs/shadow-hand-repose
 ```
 
 ---

--- a/docs/source/zh_CN/user_guide/envs/quadruped_locomotion/go1_rough_terrain.md
+++ b/docs/source/zh_CN/user_guide/envs/quadruped_locomotion/go1_rough_terrain.md
@@ -24,7 +24,7 @@ $v_y$ 和 `yaw_rate` 固定为 0。
 该任务不随机化物理参数。
 
 ```bash
-uv run scripts/view.py env=go1-stairs-terrain-walk
-uv run scripts/train.py task=go1-stairs-terrain-walk/skrl.ppo
-uv run scripts/play.py env=go1-stairs-terrain-walk
+python scripts/view.py env=go1-stairs-terrain-walk
+python scripts/train.py task=go1-stairs-terrain-walk/skrl.ppo
+python scripts/play.py env=go1-stairs-terrain-walk
 ```

--- a/docs/source/zh_CN/user_guide/envs/quadruped_velocity_tracking.md
+++ b/docs/source/zh_CN/user_guide/envs/quadruped_velocity_tracking.md
@@ -110,15 +110,15 @@ MotrixLab 已为下列机器人提供平地和程序化粗糙高度场配置。�
 从“内置机器人”表格中选择 Env ID 和对应的训练配置，并替换下列命令中的 `ENV_ID` 与 `TRAINING_CONFIG`：
 
 ```bash
-uv run scripts/view.py env=ENV_ID num_envs=1
-uv run scripts/train.py task=ENV_ID/TRAINING_CONFIG
-uv run scripts/play.py env=ENV_ID num_envs=16
+python scripts/view.py env=ENV_ID num_envs=1
+python scripts/train.py task=ENV_ID/TRAINING_CONFIG
+python scripts/play.py env=ENV_ID num_envs=16
 ```
 
 例如，使用 RSL-RL PPO 训练 Go2 粗糙地形任务：
 
 ```bash
-uv run scripts/train.py task=go2-walk-rough/rslrl.ppo
+python scripts/train.py task=go2-walk-rough/rslrl.ppo
 ```
 
 `view.py` 使用随机动作，仅用于检查场景和模型；训练后的步态需要通过 `play.py` 回放策略查看。

--- a/docs/source/zh_CN/user_guide/envs/quadruped_velocity_tracking/adding_robot.md
+++ b/docs/source/zh_CN/user_guide/envs/quadruped_velocity_tracking/adding_robot.md
@@ -67,7 +67,7 @@ class MyQuadruped(QuadrupedRobotCfg):
 完成 robot registry 注册后，先独立预览模型：
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
+python scripts/view.py robot=<robot-config-id>
 ```
 
 ## 2. 提供任务传感器
@@ -191,10 +191,10 @@ SKRL 配置选择 `/algo_base@algo: skrl.ppo`，并将 `task.rllib` 设为 `skrl
 建议按以下顺序验证：
 
 ```bash
-uv run scripts/view.py robot=<robot-config-id>
-uv run scripts/view.py env=<robot>-walk-flat
-uv run scripts/view.py env=<robot>-walk-rough
-uv run scripts/train.py task=<robot>-walk-flat/rslrl.ppo
+python scripts/view.py robot=<robot-config-id>
+python scripts/view.py env=<robot>-walk-flat
+python scripts/view.py env=<robot>-walk-rough
+python scripts/train.py task=<robot>-walk-flat/rslrl.ppo
 ```
 
 预览时重点检查默认姿态、动作方向、四脚接触、足端位置参考系和粗糙地形出生高度。

--- a/docs/source/zh_CN/user_guide/envs/whole_body_tracking/adding_wbt_task.md
+++ b/docs/source/zh_CN/user_guide/envs/whole_body_tracking/adding_wbt_task.md
@@ -41,7 +41,7 @@ motrix_envs/src/motrix_envs/locomotion/wbt/assets/motion/g1/dance1_subject1.npz
 内置 WBT 的 `ctrl_dt` 为 0.02 s，因此该 motion 应转换为 50 FPS。注册训练入口前先进行运动学 replay：
 
 ```bash
-uv run scripts/motion/replay.py \
+python scripts/motion/replay.py \
   --robot g1-29dof \
   --motion motrix_envs/src/motrix_envs/locomotion/wbt/assets/motion/g1/dance1_subject1.npz
 ```
@@ -131,7 +131,7 @@ algo:
 先用小规模 smoke test 验证 Hydra composition、registry、tensor shape 和一步训练流程：
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac \
+python scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac \
   algo.asynchronous=true num_envs=64 algo.trainer.num_learning_iterations=100
 ```
 
@@ -139,13 +139,13 @@ uv run scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac \
 `info["Reward"]` 与 `info["metrics"]` 能进入日志。随后使用默认规模训练：
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac algo.asynchronous=true
+python scripts/train.py task=g1-wbt-dance1-subject1/motrix.fastsac algo.asynchronous=true
 ```
 
 生成 metadata-backed run 后回放策略：
 
 ```bash
-uv run scripts/play.py env=g1-wbt-dance1-subject1 num_envs=16
+python scripts/play.py env=g1-wbt-dance1-subject1 num_envs=16
 ```
 
 Play 模式自动从第 0 帧开始，关闭 reset noise 和 adaptive sampler，并在 clip 结束后从头重播，无需单独注册 play 环境。

--- a/docs/source/zh_CN/user_guide/envs/whole_body_tracking/index.md
+++ b/docs/source/zh_CN/user_guide/envs/whole_body_tracking/index.md
@@ -122,7 +122,7 @@ Motion 文件由 Git LFS 管理。克隆后若 `.npz` 仍是 pointer 文本，�
 先用目标机器人的 `RobotCfg` 检查参考动作：
 
 ```bash
-uv run scripts/motion/replay.py \
+python scripts/motion/replay.py \
   --robot g1-29dof \
   --motion motrix_envs/src/motrix_envs/locomotion/wbt/assets/motion/g1/dance1_subject2.npz
 ```
@@ -136,20 +136,20 @@ uv run scripts/motion/replay.py \
 从“内置任务”表格中选择 Env ID 和对应的训练配置，并替换下列命令中的 `ENV_ID` 与 `TRAINING_CONFIG`：
 
 ```bash
-uv run scripts/train.py task=ENV_ID/TRAINING_CONFIG
+python scripts/train.py task=ENV_ID/TRAINING_CONFIG
 ```
 
 例如，使用 FastSAC 异步训练 G1 舞蹈跟踪任务：
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance/motrix.fastsac algo.asynchronous=true
+python scripts/train.py task=g1-wbt-dance/motrix.fastsac algo.asynchronous=true
 ```
 
 内置配置默认使用 2048 个并行环境，并按任务设置学习迭代次数。只验证 registry、shape 和训练入口时，可以使用不会
 生成可用策略的小规模 smoke test：
 
 ```bash
-uv run scripts/train.py task=g1-wbt-dance/motrix.fastsac \
+python scripts/train.py task=g1-wbt-dance/motrix.fastsac \
   algo.asynchronous=true num_envs=64 algo.trainer.num_learning_iterations=100
 ```
 
@@ -160,7 +160,7 @@ uv run scripts/train.py task=g1-wbt-dance/motrix.fastsac \
 ### 回放策略
 
 ```bash
-uv run scripts/play.py env=ENV_ID num_envs=16
+python scripts/play.py env=ENV_ID num_envs=16
 ```
 
 `play.py` 自动选择该环境最新一次 metadata-backed run 的最佳策略。WBT 的 play 配置从 motion 第 0 帧开始，关闭

--- a/docs/source/zh_CN/user_guide/envs/whole_body_tracking/motion_format.md
+++ b/docs/source/zh_CN/user_guide/envs/whole_body_tracking/motion_format.md
@@ -74,7 +74,7 @@ print(motion.body_names)
 模型 joint 集合和实际运动学效果：
 
 ```bash
-uv run scripts/motion/replay.py --robot g1-29dof --motion /path/to/motion.npz
+python scripts/motion/replay.py --robot g1-29dof --motion /path/to/motion.npz
 ```
 
 Replay 支持的 `--robot` 值为 `g1-29dof`、`dex-evt` 和 `k1`。
@@ -84,13 +84,13 @@ Replay 支持的 `--robot` 值为 `g1-29dof`、`dex-evt` 和 `k1`。
 查看可用的 G1 clip：
 
 ```bash
-uv run scripts/motion/download_lafan.py --list
+python scripts/motion/download_lafan.py --list
 ```
 
 下载并转换到 50 FPS：
 
 ```bash
-uv run scripts/motion/download_lafan.py \
+python scripts/motion/download_lafan.py \
   --motion dance1_subject1 \
   --output motrix_envs/src/motrix_envs/locomotion/wbt/assets/motion/g1/dance1_subject1.npz \
   --output-fps 50
@@ -99,7 +99,7 @@ uv run scripts/motion/download_lafan.py \
 也可以转换已经下载的 G1 CSV：
 
 ```bash
-uv run scripts/motion/convert.py \
+python scripts/motion/convert.py \
   --from lafan \
   --input /path/to/dance1_subject1.csv \
   --output /path/to/dance1_subject1.npz \

--- a/docs/source/zh_CN/user_guide/getting_started/hello_motrixlab.md
+++ b/docs/source/zh_CN/user_guide/getting_started/hello_motrixlab.md
@@ -2,12 +2,14 @@
 
 本教程通过演示一个简单例子 - 加载倒立摆并进行训练，以此来展示 MotrixLab 工作流程：
 
+请先完成[环境安装](installation.md)，然后激活环境：`source .venv/bin/activate`（Windows PowerShell：`.venv\Scripts\Activate.ps1`）。
+
 ## 环境预览
 
 我们提供了一个简单的脚本，用于可视化一个环境，而不执行任何训练，这可以帮助您检测系统的环境依赖是否配置正确：
 
 ```bash
-uv run scripts/view.py env=cartpole
+python scripts/view.py env=cartpole
 ```
 
 这将打开一个可视化窗口，显示倒立摆的物理仿真环境，使用随机动作进行演示。
@@ -17,7 +19,7 @@ uv run scripts/view.py env=cartpole
 开始训练倒立摆平衡任务：
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
 ```
 
 训练过程会自动：
@@ -36,7 +38,7 @@ uv run scripts/train.py task=cartpole/skrl.ppo
 如果您想要在训练过程中观察模型的学习过程，可以启用可视化渲染：
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo render=true
+python scripts/train.py task=cartpole/skrl.ppo render=true
 ```
 
 ### 🎮 交互式渲染控制
@@ -56,7 +58,7 @@ uv run scripts/train.py task=cartpole/skrl.ppo render=true
 使用 TensorBoard 查看训练进度：
 
 ```bash
-uv run tensorboard --logdir runs/cartpole
+tensorboard --logdir runs/cartpole
 ```
 
 ## 测试训练好的模型
@@ -65,10 +67,10 @@ uv run tensorboard --logdir runs/cartpole
 
 ```bash
 # 自动寻找最佳策略测试（推荐）
-uv run scripts/play.py env=cartpole
+python scripts/play.py env=cartpole
 
 # 手动指定带 metadata 的 run 中的 checkpoint
-uv run scripts/play.py env=cartpole policy=/path/to/run/checkpoints/policy-file
+python scripts/play.py env=cartpole policy=/path/to/run/checkpoints/policy-file
 ```
 
 > **提示**：系统会自动在 `runs/cartpole/` 下寻找最新 run 的最佳策略。手动指定的 checkpoint 必须属于包含 `metadata.json` 和 `task_config.yaml` 的 run。

--- a/docs/source/zh_CN/user_guide/getting_started/installation.md
+++ b/docs/source/zh_CN/user_guide/getting_started/installation.md
@@ -41,70 +41,80 @@ git clone https://github.com/Motphys/MotrixLab.git
 cd MotrixLab
 ```
 
-### 配置依赖环境
+### 安装运行环境
+
+在仓库根目录执行以下命令安装运行环境（Windows 上请在 PowerShell 中执行 `install.ps1`；若执行策略受限，改用 `powershell -ExecutionPolicy Bypass -File install.ps1`）：
+
+```bash
+sh install.sh
+```
+
+该命令会自动探测 GPU 厂商（NVIDIA → CUDA，AMD → ROCm），安装全部 workspace package、对应的
+PyTorch wheel、SKRL 训练框架以及内置的 FastSAC 算法。
 
 :::{dropdown} 配置国内镜像源（可选）
 :animate: fade-in
 :color: warning
 :icon: desktop-download
-如果您身处中国大陆，建议配置国内镜像源以加速依赖下载：
+如果您身处中国大陆，建议配置国内镜像源以加速依赖下载。修改项目根目录的 `uv.toml` 文件：
 
-1. 修改项目根目录的 `uv.toml` 文件
-
-    ```toml
-    [[index]]
-    name = "mirror"
-    # 请填写您选择的国内镜像源，例如：
-    # 清华源: "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
-    url = ""
+```toml
+[[index]]
+name = "mirror"
+# 请填写您选择的国内镜像源，例如：
+# 清华源: "https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple"
+url = ""
 
 
-    [[index]]
-    name = "pytorch"
-    url = "https://download.pytorch.org/whl/cu128"
-    default = true
-    ```
+[[index]]
+name = "pytorch"
+url = "https://download.pytorch.org/whl/cu128"
+default = true
+```
 
-2. 在执行 `uv sync` 命令时添加 `--index-strategy unsafe-best-match` 参数：
-
-    ```
-    uv sync --all-packages --all-groups --all-extras --index-strategy unsafe-best-match
-    ```
+然后重新执行 `sh install.sh` 即可生效。
 
 :::
 
-执行以下命令安装完整依赖：
+### 激活环境
+
+安装完成后，先激活环境再运行命令（Windows PowerShell：`.venv\Scripts\Activate.ps1`）：
 
 ```bash
-# 安装所有依赖
-uv sync --all-packages --all-groups --all-extras
+source .venv/bin/activate
 ```
 
-如果仅需特定训练框架，可选择性安装以减少依赖体积：
+```{note}
+避免裸 `uv sync` / `uv run`：CUDA 与 ROCm wheel 由互斥的 extras 选择，裸命令会解析到默认的 PyPI
+分支并重装环境。请从激活后的环境运行命令，或对单条命令使用 `uv run --no-sync`。
+```
+
+## 开发环境安装
+
+上述运行环境只包含训练与部署所需的依赖。如果你要参与开发（运行测试、修改代码、构建文档），
+执行以下命令安装完整开发环境：
 
 ```bash
-
-# 安装 SKRL JAX （仅支持 Linux 平台）
-uv sync --all-packages --extra skrl-jax
-
-# 安装 SKRL PyTorch
-uv sync --all-packages --extra skrl-torch
-
-# 安装 RSLRL（仅支持 PyTorch）
-uv sync --all-packages --extra rslrl
+sh install.sh --all
 ```
 
-## Package 边界
+`--all` 会把所有依赖一次性全部启用：开发工具链、测试依赖、全部训练后端
+（`--skrl-jax` / `--rslrl`）与文档工具。也可以在运行环境基础上按需追加，
+例如 `sh install.sh --docs` 只补文档工具链。
 
--   `motrix-env-core` 提供环境 framework，不包含内置任务和资产。
--   `motrix-envs` 依赖 core package，包含所有内置环境、机器人模型和任务数据。
--   `motrix-rl` 仅依赖 core package，不强制安装内置环境。
+## 安装参数参考
 
-外部项目实现自定义环境时可以只安装 `motrix-env-core`；使用内置任务时安装 `motrix-envs`。导入
-`motrix_envs` 时会完成内置环境注册。
+所有模式都会安装全部 workspace package；运行环境在此基础上启用「1 个 GPU extra ＋ 训练后端 extra」，
+各参数只负责选择或追加：
 
-```python
-from motrix_envs import registry
-from motrix_env_core.direct.env import DirectEnv
-from motrix_envs.core import EnvCfg, SceneCfg, configclass
-```
+| 参数 | 可选值 | 说明 |
+| ---- | ------ | ---- |
+| `--all` | — | 完整开发环境：把下述所有依赖一次性全部启用（开发工具链、测试依赖、全部训练后端与文档工具） |
+| （无参数） | — | 运行环境；自动探测 GPU 厂商（NVIDIA → CUDA，AMD → ROCm，无法探测时回退 CUDA） |
+| `--gpu` | `cuda`<br>`rocm` | 指定 torch wheel 来源，覆盖自动探测 |
+| `--skrl-jax` | — | SKRL（JAX）训练后端，仅 Linux |
+| `--rslrl` | — | RSL-RL（PyTorch）训练后端 |
+| `--docs` | — | 追加本地构建文档所需的工具链（Sphinx） |
+| `-h`、`--help` | — | 显示帮助 |
+
+完整参数说明见 `sh install.sh --help`。

--- a/docs/source/zh_CN/user_guide/robots.md
+++ b/docs/source/zh_CN/user_guide/robots.md
@@ -134,8 +134,8 @@ registry.robotcfg("my-robot")(MyRobot)
 先通过 registry 构造配置并预览机器人：
 
 ```bash
-uv run scripts/view.py robot=my-robot
-uv run pytest motrix_envs/tests/test_robot_cfg.py -q
+python scripts/view.py robot=my-robot
+python -m pytest motrix_envs/tests/test_robot_cfg.py -q
 ```
 
 至少应验证模型能够构建、`base_link_name` 存在、关节与 actuator 对应、默认 key pose 完整，以及任务需要的碰撞体和 site
@@ -146,8 +146,8 @@ uv run pytest motrix_envs/tests/test_robot_cfg.py -q
 `_ROBOT_METADATA` 中补充类型和截图参数，然后生成截图与表格：
 
 ```bash
-uv run docs/scripts/generate_robot_docs.py --screenshots my-robot
-uv run docs/scripts/generate_robot_docs.py --check
+python docs/scripts/generate_robot_docs.py --screenshots my-robot
+python docs/scripts/generate_robot_docs.py --check
 ```
 
 ## 独立预览
@@ -155,7 +155,7 @@ uv run docs/scripts/generate_robot_docs.py --check
 使用 `view.py` 可以在默认姿态下查看已注册 robot，无需创建 RL environment：
 
 ```bash
-uv run scripts/view.py robot=go2
+python scripts/view.py robot=go2
 ```
 
 robot 模式会构建一个静态标准场景，不采样 action，也不执行 physics rollout。

--- a/docs/source/zh_CN/user_guide/tutorial/basic_frame.md
+++ b/docs/source/zh_CN/user_guide/tutorial/basic_frame.md
@@ -88,7 +88,7 @@ Trainer 负责框架特有的模型创建、优化、checkpoint 序列化和推�
 例如：
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo num_envs=1024
+python scripts/train.py task=cartpole/skrl.ppo num_envs=1024
 ```
 
 该命令会依次执行：
@@ -104,8 +104,8 @@ uv run scripts/train.py task=cartpole/skrl.ppo num_envs=1024
 同一个环境可以拥有多份 Task 配方，不需要修改环境实现：
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
-uv run scripts/train.py task=cartpole/rslrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/rslrl.ppo
 ```
 
 SKRL 提供 JAX 与 Torch provider，RSLRL 使用 Torch；`motrix.fastsac` 通过 `algo.asynchronous` 选择同步或异步 Torch trainer。所选 Task 与 provider 共同决定算法配置和输出 metadata。

--- a/docs/source/zh_CN/user_guide/tutorial/custom_training_backend.md
+++ b/docs/source/zh_CN/user_guide/tutorial/custom_training_backend.md
@@ -193,7 +193,7 @@ seed: 42
 如果后端已经在启动路径中完成注册，可以直接用 CLI：
 
 ```bash
-uv run scripts/train.py task=cartpole/myrl.ppo
+python scripts/train.py task=cartpole/myrl.ppo
 ```
 
 如果是外部实验包，使用自己的 Hydra config root，并在进入训练入口前导入 backend 注册模块。无需额外的 Python task registry。

--- a/docs/source/zh_CN/user_guide/tutorial/export_onnx.md
+++ b/docs/source/zh_CN/user_guide/tutorial/export_onnx.md
@@ -18,17 +18,8 @@ SKRL/JAX checkpoint 暂不支持导出。导出命令接收完整的 run 目录�
 
 ## 安装依赖
 
-在仓库根目录安装 ONNX 依赖以及训练所用的后端：
-
-```bash
-# SKRL/Torch 或 Motrix FastSAC
-uv sync --all-packages --extra onnx --extra skrl-torch
-
-# RSL-RL
-uv sync --all-packages --extra onnx --extra rslrl
-```
-
-如果使用 `uv sync --all-packages --all-groups --all-extras` 完成安装，则不需要额外操作。
+无需额外步骤：ONNX 导出与推理所需的依赖（`onnx`、`onnxruntime`）已包含在 `sh install.sh`
+安装的默认运行环境中（参见[安装环境](../getting_started/installation.md)）。
 
 ## 导出模型
 
@@ -41,7 +32,7 @@ runs/cartpole/skrl/torch/ppo/<timestamp>/
 指定输出文件进行导出：
 
 ```bash
-uv run scripts/export_onnx.py \
+python scripts/export_onnx.py \
   run_dir=runs/cartpole/skrl/torch/ppo/<timestamp> \
   output=artifacts/cartpole.onnx
 ```
@@ -51,7 +42,7 @@ uv run scripts/export_onnx.py \
 如果省略 `output`，模型会写入最佳 checkpoint 所在目录，文件名为 `policy.onnx`：
 
 ```bash
-uv run scripts/export_onnx.py \
+python scripts/export_onnx.py \
   run_dir=runs/cartpole/skrl/torch/ppo/<timestamp>
 ```
 
@@ -113,7 +104,7 @@ print(actions)
 例如，导出为 opset 17，并增加检查样本数：
 
 ```bash
-uv run scripts/export_onnx.py \
+python scripts/export_onnx.py \
   run_dir=<run-dir> \
   output=policy.onnx \
   opset=17 \

--- a/docs/source/zh_CN/user_guide/tutorial/motrix_deploy.md
+++ b/docs/source/zh_CN/user_guide/tutorial/motrix_deploy.md
@@ -8,7 +8,7 @@
 在仓库根目录执行：
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+sh install.sh --all
 ```
 
 这个命令会安装训练、MuJoCo、ONNX Runtime 和 Unitree SDK2 依赖。
@@ -18,7 +18,7 @@ uv sync --all-packages --all-groups --all-extras
 没有现成 run 时，训练 flat-terrain Go2 策略：
 
 ```bash
-uv run scripts/train.py task=go2-walk-flat/rslrl.ppo
+python scripts/train.py task=go2-walk-flat/rslrl.ppo
 ```
 
 训练结果保存在 `runs/go2-walk-flat/`。
@@ -28,7 +28,7 @@ uv run scripts/train.py task=go2-walk-flat/rslrl.ppo
 导出最近一次 run：
 
 ```bash
-uv run scripts/export_deploy.py env=go2-walk-flat
+python scripts/export_deploy.py env=go2-walk-flat
 ```
 
 输出目录为 `artifacts/go2-walk-flat.deploy/`。artifact 是部署时唯一需要带走的策略文件，包含模型和运行所需的配置。
@@ -36,7 +36,7 @@ uv run scripts/export_deploy.py env=go2-walk-flat
 ## 4. 检查 artifact
 
 ```bash
-uv run motrix-deploy inspect \
+motrix-deploy inspect \
   artifact=artifacts/go2-walk-flat.deploy
 ```
 
@@ -45,7 +45,7 @@ uv run motrix-deploy inspect \
 ## 5. 先跑 Sim2Sim
 
 ```bash
-uv run motrix-deploy sim2sim \
+motrix-deploy sim2sim \
   --config-name go2_walk_flat_sim2sim \
   artifact=artifacts/go2-walk-flat.deploy
 ```
@@ -58,10 +58,10 @@ uv run motrix-deploy sim2sim \
 将 `enp5s0` 换成实际网卡名称：
 
 ```bash
-uv run motrix-deploy inspect \
+motrix-deploy inspect \
   artifact=artifacts/go2-walk-flat.deploy
 
-uv run motrix-deploy sim2real \
+motrix-deploy sim2real \
   --config-name go2_walk_flat_sim2real \
   artifact=artifacts/go2-walk-flat.deploy \
   backend.network_interface=enp5s0 \
@@ -73,7 +73,7 @@ uv run motrix-deploy sim2real \
 发送策略前，也可以先查看机器人状态：
 
 ```bash
-uv run python -m motrix_deploy_unitree.read_lowstate enp5s0
+python -m motrix_deploy_unitree.read_lowstate enp5s0
 ```
 
 ## 进阶说明
@@ -85,7 +85,7 @@ uv run python -m motrix_deploy_unitree.read_lowstate enp5s0
 覆盖 12 个关节：
 
 ```bash
-uv run motrix-deploy sim2real \
+motrix-deploy sim2real \
   artifact=artifacts/go2-walk-flat.deploy \
   backend.network_interface=enp5s0 \
   'backend.kp=[20,25,30,20,25,30,22,27,32,22,27,32]' \
@@ -98,7 +98,7 @@ uv run motrix-deploy sim2real \
 发送任何运动指令前，可先运行只读诊断：
 
 ```bash
-uv run python -m motrix_deploy_unitree.read_lowstate enp5s0
+python -m motrix_deploy_unitree.read_lowstate enp5s0
 ```
 
 ### 发送单关节运动指令
@@ -107,7 +107,7 @@ uv run python -m motrix_deploy_unitree.read_lowstate enp5s0
 `go2-walk-flat` deployment profile 构建控制契约，不需要训练 run、checkpoint、策略或 deployment artifact：
 
 ```bash
-uv run python -m motrix_deploy_unitree.go2_joint_control \
+python -m motrix_deploy_unitree.go2_joint_control \
   enp5s0 \
   FL_thigh_joint \
   0.9 \

--- a/docs/source/zh_CN/user_guide/tutorial/runs_and_checkpoints.md
+++ b/docs/source/zh_CN/user_guide/tutorial/runs_and_checkpoints.md
@@ -106,16 +106,16 @@ runs/g1-walk-flat/motrix/torch/fastsac/26-07-06_11-37-50-376526/
 
     ```bash
     # 自动发现最新 run 的最佳策略
-    uv run scripts/play.py env=g1-walk-flat
+    python scripts/play.py env=g1-walk-flat
 
     # 指定某个 checkpoint（需能向上找到 metadata.json）
-    uv run scripts/play.py env=g1-walk-flat policy=/path/to/run/checkpoints/latest.pt
+    python scripts/play.py env=g1-walk-flat policy=/path/to/run/checkpoints/latest.pt
     ```
 
 -   **续训（resume）**：将 `resume=` 设置为 run 目录或 checkpoint 路径，框架据此解析出 `latest_training_state` 继续训练。
 
     ```bash
-    uv run scripts/train.py task=g1-walk-flat/motrix.fastsac \
+    python scripts/train.py task=g1-walk-flat/motrix.fastsac \
       resume=/path/to/run
     ```
 
@@ -124,5 +124,5 @@ runs/g1-walk-flat/motrix/torch/fastsac/26-07-06_11-37-50-376526/
 TensorBoard 日志（`events.out.tfevents.*`）直接写在 run 根目录下，可按环境查看：
 
 ```bash
-uv run tensorboard --logdir runs/g1-walk-flat
+tensorboard --logdir runs/g1-walk-flat
 ```

--- a/docs/source/zh_CN/user_guide/tutorial/training_and_result.md
+++ b/docs/source/zh_CN/user_guide/tutorial/training_and_result.md
@@ -10,12 +10,12 @@
 
 ```bash
 # 训练默认的 Cartpole SKRL PPO Task
-uv run scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/skrl.ppo
 
 # 选择其他框架或算法
-uv run scripts/train.py task=cartpole/rslrl.ppo
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac algo.asynchronous=false
+python scripts/train.py task=cartpole/rslrl.ppo
+python scripts/train.py task=g1-walk-flat/motrix.fastsac
+python scripts/train.py task=g1-walk-flat/motrix.fastsac algo.asynchronous=false
 ```
 
 当前内置的 RL method 与训练后端：
@@ -26,28 +26,28 @@ uv run scripts/train.py task=g1-walk-flat/motrix.fastsac algo.asynchronous=false
 | `rslrl.ppo`      | `torch`         | RSLRL PPO                                       |
 | `motrix.fastsac` | `torch`         | FastSAC；`algo.asynchronous` 选择同步或异步拓扑 |
 
-运行 `uv run scripts/train.py --help` 可以查看当前代码中全部可选 Task。Task 文件结构和覆盖规则见 [Task 配置与命令行参数覆盖](training_environment_config.md)。
+运行 `python scripts/train.py --help` 可以查看当前代码中全部可选 Task。Task 文件结构和覆盖规则见 [Task 配置与命令行参数覆盖](training_environment_config.md)。
 
 ### 选择训练后端与仿真后端
 
 ```bash
 # 覆盖训练后端（task.train_backend 为 null 时自动选择）
-uv run scripts/train.py task=cartpole/skrl.ppo task.train_backend=jax
-uv run scripts/train.py task=cartpole/skrl.ppo task.train_backend=torch
+python scripts/train.py task=cartpole/skrl.ppo task.train_backend=jax
+python scripts/train.py task=cartpole/skrl.ppo task.train_backend=torch
 
 # 指定 manager 环境注入的仿真器
-uv run scripts/train.py task=g1-wbt-dance sim=motrixsim
+python scripts/train.py task=g1-wbt-dance sim=motrixsim
 ```
 
 ### 训练规模与随机种子
 
 ```bash
 # 并行环境数量
-uv run scripts/train.py task=cartpole/skrl.ppo num_envs=1024
+python scripts/train.py task=cartpole/skrl.ppo num_envs=1024
 
 # 固定随机种子（复现）/ 运行时选择随机种子
-uv run scripts/train.py task=cartpole/skrl.ppo seed=42
-uv run scripts/train.py task=cartpole/skrl.ppo seed=null
+python scripts/train.py task=cartpole/skrl.ppo seed=42
+python scripts/train.py task=cartpole/skrl.ppo seed=null
 ```
 
 ```{note}
@@ -58,14 +58,14 @@ Hydra 可以直接覆盖已经声明的算法字段，例如 `algo.agent.learnin
 
 ```bash
 # 训练成功结束后，用本次 run 的最佳策略自动回放
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac play=true
+python scripts/train.py task=g1-walk-flat/motrix.fastsac play=true
 
 # 从某个 run 目录或 checkpoint 续训
-uv run scripts/train.py task=g1-walk-flat/motrix.fastsac \
+python scripts/train.py task=g1-walk-flat/motrix.fastsac \
   resume=/path/to/run
 
 # 启用渲染监控训练过程
-uv run scripts/train.py task=cartpole/skrl.ppo render=true
+python scripts/train.py task=cartpole/skrl.ppo render=true
 ```
 
 ### 常用 Hydra 覆盖项
@@ -92,7 +92,7 @@ uv run scripts/train.py task=cartpole/skrl.ppo render=true
 TensorBoard 日志写在 run 目录下，可按环境查看：
 
 ```bash
-uv run tensorboard --logdir runs/cartpole
+tensorboard --logdir runs/cartpole
 ```
 
 除标准的回报、损失曲线外，若环境通过 `info["Reward"]` 暴露了各 reward 分项，训练时也会将其记录到 TensorBoard。
@@ -103,14 +103,14 @@ uv run tensorboard --logdir runs/cartpole
 
 ```bash
 # 自动发现最新 run 的最佳策略并回放（推荐）
-uv run scripts/play.py env=cartpole
+python scripts/play.py env=cartpole
 
 # 指定某个 checkpoint（需能向上找到 metadata.json）
-uv run scripts/play.py env=g1-walk-flat \
+python scripts/play.py env=g1-walk-flat \
   policy=/path/to/run/checkpoints/latest.pt
 
 # 指定回放环境数量
-uv run scripts/play.py env=cartpole num_envs=100
+python scripts/play.py env=cartpole num_envs=100
 ```
 
 ```{note}

--- a/docs/source/zh_CN/user_guide/tutorial/training_environment_config.md
+++ b/docs/source/zh_CN/user_guide/tutorial/training_environment_config.md
@@ -65,19 +65,19 @@ Task 只需填写与算法基础配置不同的值，不需要复制所有算法
 启动训练前，可以先输出 Hydra 组合后的完整配置：
 
 ```bash
-uv run scripts/train.py --cfg job --resolve task=my-robot/skrl.ppo
+python scripts/train.py --cfg job --resolve task=my-robot/skrl.ppo
 ```
 
 该命令不会开始训练。确认 `task.env`、`num_envs` 和 `algo.trainer.timesteps` 符合预期后，再启动训练：
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo
+python scripts/train.py task=my-robot/skrl.ppo
 ```
 
 运行以下命令可以查看仓库中所有可选 Task：
 
 ```bash
-uv run scripts/train.py --help
+python scripts/train.py --help
 ```
 
 ## 调整 Task 的运行参数
@@ -191,7 +191,7 @@ MotrixLab CLI 使用 Hydra 的 `key=value` 参数语法。CLI 覆盖只影响本
 ### 覆盖运行参数
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=my-robot/skrl.ppo \
   num_envs=64 \
   seed=7 \
@@ -202,7 +202,7 @@ uv run scripts/train.py \
 开启训练渲染，并在训练完成后播放：
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo render=true play=true
+python scripts/train.py task=my-robot/skrl.ppo render=true play=true
 ```
 
 ### 覆盖算法参数
@@ -210,7 +210,7 @@ uv run scripts/train.py task=my-robot/skrl.ppo render=true play=true
 SKRL PPO：
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=my-robot/skrl.ppo \
   algo.agent.learning_rate=5e-4 \
   algo.agent.learning_epochs=8 \
@@ -220,7 +220,7 @@ uv run scripts/train.py \
 RSLRL PPO：
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=cartpole/rslrl.ppo \
   algo.algorithm.learning_rate=5e-4 \
   algo.algorithm.entropy_coef=0.005 \
@@ -230,7 +230,7 @@ uv run scripts/train.py \
 FastSAC：
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=g1-walk-flat/motrix.fastsac \
   algo.asynchronous=true \
   algo.agent.actor_learning_rate=1e-4 \
@@ -244,20 +244,20 @@ uv run scripts/train.py \
 布尔值使用小写 `true` 或 `false`：
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo render=true
+python scripts/train.py task=my-robot/skrl.ppo render=true
 ```
 
 使用 `null` 清空可空字段：
 
 ```bash
-uv run scripts/train.py task=my-robot/skrl.ppo seed=null
-uv run scripts/train.py task=my-robot/skrl.ppo algo.agent.learning_rate_scheduler=null
+python scripts/train.py task=my-robot/skrl.ppo seed=null
+python scripts/train.py task=my-robot/skrl.ppo algo.agent.learning_rate_scheduler=null
 ```
 
 列表建议使用引号，避免 shell 解释方括号：
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   task=my-robot/skrl.ppo \
   'algo.models.policy.hiddens=[128,64]' \
   'algo.models.value.hiddens=[128,64]'
@@ -274,7 +274,7 @@ uv run scripts/train.py \
 将 CLI 覆盖和 `--cfg job --resolve` 组合，可以查看本次运行最终会使用的值：
 
 ```bash
-uv run scripts/train.py \
+python scripts/train.py \
   --cfg job \
   --resolve \
   task=my-robot/skrl.ppo \
@@ -316,13 +316,13 @@ algo:
 使用 JAX 差异配置训练：
 
 ```bash
-uv run scripts/train.py task=go2-walk-flat/skrl.ppo.jax
+python scripts/train.py task=go2-walk-flat/skrl.ppo.jax
 ```
 
 直接覆盖后端也可以选择 JAX 训练器：
 
 ```bash
-uv run scripts/train.py task=go2-walk-flat/skrl.ppo task.train_backend=jax
+python scripts/train.py task=go2-walk-flat/skrl.ppo task.train_backend=jax
 ```
 
 这种写法不会加载 `skrl.ppo.jax.yaml` 中的后端专用参数。当后端差异文件存在时，应直接选择带 `.jax` 或 `.torch` 后缀的 Task。
@@ -413,15 +413,15 @@ Hydra 会根据 provider 注册的结构化 schema 检查字段名和类型。�
 `scripts/play.py` 和 `scripts/view.py` 同样使用 `key=value` 语法：
 
 ```bash
-uv run scripts/view.py env=cartpole num_envs=4
-uv run scripts/play.py env=cartpole num_envs=1
-uv run scripts/play.py policy=/path/to/checkpoint.pt num_envs=1
+python scripts/view.py env=cartpole num_envs=4
+python scripts/play.py env=cartpole num_envs=1
+python scripts/play.py policy=/path/to/checkpoint.pt num_envs=1
 ```
 
 Play 默认读取训练 run 中保存的 `task_config.yaml`。如需临时覆盖其中的算法参数，使用 `rl` 作为算法配置根节点。因为 `rl` 初始为空，需要用 `+` 添加路径：
 
 ```bash
-uv run scripts/play.py \
+python scripts/play.py \
   env=cartpole \
   '+rl.agent.learning_rate=1e-4'
 ```

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,32 @@
+# Copyright Motphys Technology Co., Ltd. 2025, 2026
+# SPDX-License-Identifier: Apache-2.0
+
+# Windows entry point: delegates to install.sh through the Git Bash bundled
+# with Git for Windows. If the PowerShell execution policy blocks direct
+# invocation, run: powershell -ExecutionPolicy Bypass -File install.ps1
+
+Set-Location -Path $PSScriptRoot -ErrorAction Stop
+
+# Prefer the Git Bash shipped with Git for Windows, derived from git.exe:
+# ...\Git\cmd\git.exe -> ...\Git\bin\bash.exe
+$bash = $null
+$git = (Get-Command git -ErrorAction SilentlyContinue).Source
+if ($git) {
+    $candidate = $git -replace '\\cmd\\git\.exe$', '\bin\bash.exe' -replace '\\mingw64\\bin\\git\.exe$', '\bin\bash.exe'
+    if ($candidate -ne $git -and (Test-Path $candidate)) {
+        $bash = $candidate
+    }
+}
+
+# Fall back to any bash on PATH (Git Bash, MSYS2, Cygwin or WSL all work).
+if (-not $bash) {
+    $bash = (Get-Command bash -ErrorAction SilentlyContinue).Source
+}
+
+if (-not $bash) {
+    Write-Error "bash.exe not found: Git for Windows is required. Install it from https://git-scm.com/download/win and retry."
+    exit 1
+}
+
+& $bash install.sh @args
+exit $LASTEXITCODE

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,167 @@
+#!/bin/sh
+# Copyright Motphys Technology Co., Ltd. 2025, 2026
+# SPDX-License-Identifier: Apache-2.0
+
+# Project bootstrap: runtime environment (`sh install.sh`) or full
+# development environment (`sh install.sh --all`).
+#
+# GPU wheel flavor (--gpu): cuda or rocm. When not given explicitly, detect
+# from the loaded kernel driver (nvidia -> cuda, amdgpu -> rocm); CPU-only
+# hosts fall back to cuda.
+#
+# Training backends are enabled with --skrl-torch (default), --skrl-jax or
+# --rslrl, named after the extras that install them; multiple flags combine.
+
+set -e
+
+usage() {
+    echo "Usage: sh install.sh [options]"
+    echo
+    echo "Options:"
+    echo "  --all                  Install the full development environment (all packages, groups and extras;"
+    echo "                         ROCm hosts skip CUDA-only extras such as skrl-jax)"
+    echo "  --docs                 Include the docs toolchain (sphinx) for building the documentation"
+    echo "  --gpu cuda|rocm        GPU wheel flavor (default: auto-detected from the kernel driver)"
+    echo "  --skrl-torch           Training backend: SKRL on PyTorch (default)"
+    echo "  --skrl-jax             Training backend: SKRL on JAX (Linux only)"
+    echo "  --rslrl                Training backend: RSL-RL on PyTorch"
+    echo "  -h, --help             Show this help"
+}
+
+ALL=""
+GPU=""
+SKRL_TORCH=""
+SKRL_JAX=""
+RSLRL=""
+DOCS=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --all)
+            ALL=1
+            ;;
+        --docs)
+            DOCS=1
+            ;;
+        --gpu)
+            [ $# -ge 2 ] || { echo "error: $1 requires a value (cuda or rocm)" >&2; exit 1; }
+            GPU="$2"
+            shift
+            ;;
+        --skrl-torch)
+            SKRL_TORCH=1
+            ;;
+        --skrl-jax)
+            SKRL_JAX=1
+            ;;
+        --rslrl)
+            RSLRL=1
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown option: $1" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ -n "$GPU" ] && [ "$GPU" != cuda ] && [ "$GPU" != rocm ]; then
+    echo "error: invalid --gpu value: $GPU (expected cuda or rocm)" >&2
+    usage >&2
+    exit 1
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+    echo "==> uv not found, installing..."
+    case "$(uname -s 2>/dev/null)" in
+        MINGW*|MSYS*|CYGWIN*)
+            # Native Windows (Git Bash): use the official PowerShell installer.
+            powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+            ;;
+        *)
+            if command -v curl >/dev/null 2>&1; then
+                curl -LsSf https://astral.sh/uv/install.sh | sh
+            elif command -v wget >/dev/null 2>&1; then
+                wget -qO- https://astral.sh/uv/install.sh | sh
+            else
+                echo "error: neither curl nor wget found; install uv manually:" >&2
+                echo "       https://docs.astral.sh/uv/getting-started/installation/" >&2
+                exit 1
+            fi
+            ;;
+    esac
+    export PATH="$HOME/.local/bin:$PATH"
+    if ! command -v uv >/dev/null 2>&1; then
+        echo "error: uv installation failed; install it manually:" >&2
+        echo "       https://docs.astral.sh/uv/getting-started/installation/" >&2
+        exit 1
+    fi
+fi
+
+# Robot assets (STL/OBJ meshes, motion data) are stored via Git LFS; pull them
+# so training does not hit pointer files. `git lfs pull` is incremental and
+# skips objects already present on disk.
+if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    if git lfs version >/dev/null 2>&1; then
+        git lfs install >/dev/null 2>&1 || true
+        echo "==> Pulling Git LFS assets (robot meshes, motion data)..."
+        set -x
+        git lfs pull
+        set +x
+    else
+        echo "error: git-lfs is not installed, but robot assets are stored via Git LFS" >&2
+        echo "       and training will fail without them. Install it with:" >&2
+        echo "         Windows (Git Bash): winget install GitHub.git-lfs" >&2
+        echo "         Debian/Ubuntu:      sudo apt install git-lfs" >&2
+        echo "         Fedora/RHEL:        sudo dnf install git-lfs" >&2
+        echo "         macOS:              brew install git-lfs" >&2
+        echo "       then run: git lfs install && git lfs pull" >&2
+        exit 1
+    fi
+fi
+
+if [ -z "$GPU" ]; then
+    if lsmod 2>/dev/null | grep -q '^nvidia '; then
+        GPU=cuda
+    elif lsmod 2>/dev/null | grep -q '^amdgpu '; then
+        GPU=rocm
+    else
+        GPU=cuda
+    fi
+fi
+
+case "$(uname -s 2>/dev/null)" in
+    MINGW*|MSYS*|CYGWIN*) IS_WINDOWS=1 ;;
+    *) IS_WINDOWS="" ;;
+esac
+
+if [ "$GPU" = rocm ] && [ -n "$IS_WINDOWS" ]; then
+    echo "error: --gpu rocm is not available on Windows; ROCm wheels are Linux-only" >&2
+    exit 1
+fi
+
+if [ -n "$ALL" ]; then
+    if [ "$GPU" = rocm ]; then
+        set -x
+        uv sync --all-packages --all-groups --extra rocm --extra skrl-torch --extra rslrl --extra unitree --extra docs
+    else
+        set -x
+        uv sync --all-packages --all-groups --all-extras --no-extra rocm
+    fi
+else
+    if [ -z "$SKRL_TORCH" ] && [ -z "$SKRL_JAX" ] && [ -z "$RSLRL" ]; then
+        SKRL_TORCH=1
+    fi
+    EXTRAS=""
+    [ -n "$SKRL_TORCH" ] && EXTRAS="$EXTRAS --extra skrl-torch"
+    [ -n "$SKRL_JAX" ] && EXTRAS="$EXTRAS --extra skrl-jax"
+    [ -n "$RSLRL" ] && EXTRAS="$EXTRAS --extra rslrl"
+    [ -n "$DOCS" ] && EXTRAS="$EXTRAS --extra docs"
+    set -x
+    uv sync --all-packages --no-default-groups --extra "$GPU"$EXTRAS
+fi

--- a/motrix_deploy/README.md
+++ b/motrix_deploy/README.md
@@ -13,30 +13,30 @@ on a physical Go2.
 From the repository root, install the required development extras:
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+sh install.sh --all
 ```
 
 Export a new artifact directory, validate it without opening a backend, and run an interactive deployment:
 
 ```bash
-uv run scripts/export_deploy.py env=go2-walk-rough
+python scripts/export_deploy.py env=go2-walk-rough
 
-uv run motrix-deploy inspect \
+motrix-deploy inspect \
   artifact=artifacts/go2-walk-rough.deploy
 
-uv run motrix-deploy sim2sim \
+motrix-deploy sim2sim \
   artifact=artifacts/go2-walk-rough.deploy
 ```
 
 For the flat-terrain environment, export its own artifact and select the matching runtime recipe:
 
 ```bash
-uv run scripts/export_deploy.py env=go2-walk-flat
+python scripts/export_deploy.py env=go2-walk-flat
 
-uv run motrix-deploy inspect \
+motrix-deploy inspect \
   artifact=artifacts/go2-walk-flat.deploy
 
-uv run motrix-deploy sim2sim \
+motrix-deploy sim2sim \
   --config-name go2_walk_flat_sim2sim \
   artifact=artifacts/go2-walk-flat.deploy
 ```
@@ -56,16 +56,17 @@ actuator range, servo gain, tensor shape, checksum, and command-range mismatches
 Headless and physical runs may set either `rollout.steps` or `rollout.duration_s`; viewer runs may leave both unset.
 `realtime` defaults to the viewer mode when omitted.
 
-Optional dependencies remain isolated behind extras for smaller runtime environments:
+Optional dependencies remain isolated behind extras for smaller runtime environments (ONNX
+inference is a core dependency; `mujoco` and `unitree` select the deployment backends):
 
 ```bash
-uv sync --package motrix-deploy-tasks --extra onnx --extra mujoco --extra unitree
+uv sync --package motrix-deploy-tasks --extra mujoco --extra unitree
 ```
 
 Interactive deployment reads keyboard events directly from the focused GLFW viewer window:
 
 ```bash
-uv run motrix-deploy sim2sim \
+motrix-deploy sim2sim \
   artifact=artifacts/go2-walk-rough.deploy
 ```
 
@@ -84,17 +85,17 @@ The hardware plugin imports the Unitree SDK2 Python package only when a physical
 workspace sync installs the pinned Motphys-maintained fork into the same environment:
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+sh install.sh --all
 ```
 
 Inspect the artifact first. With the robot suspended, low-level/debug mode enabled, Ethernet connected, and an emergency
 stop operator ready, explicitly select the interface and confirm the hardware checklist:
 
 ```bash
-uv run motrix-deploy inspect \
+motrix-deploy inspect \
   artifact=artifacts/go2-walk-rough.deploy
 
-uv run motrix-deploy sim2real \
+motrix-deploy sim2real \
   artifact=artifacts/go2-walk-rough.deploy \
   backend.network_interface=enp3s0 \
   hardware.confirm=true

--- a/motrix_deploy/pyproject.toml
+++ b/motrix_deploy/pyproject.toml
@@ -10,7 +10,11 @@ authors = [{ name = "Motphys", email = "developers@motphys.com" }]
 requires-python = "==3.10.*"
 readme = "README.md"
 license = "Apache-2.0"
-dependencies = ["hydra-core>=1.3,<1.4", "motrix-env-core", "numpy>=1.26"]
-
-[project.optional-dependencies]
-onnx = ["onnxruntime==1.23.2"]
+# onnxruntime is a core dependency: deployed policies are ONNX artifacts, so
+# every deployment runtime needs it for inference.
+dependencies = [
+    "hydra-core>=1.3,<1.4",
+    "motrix-env-core",
+    "numpy>=1.26",
+    "onnxruntime==1.23.2",
+]

--- a/motrix_deploy/src/motrix_deploy/policy/__init__.py
+++ b/motrix_deploy/src/motrix_deploy/policy/__init__.py
@@ -48,7 +48,9 @@ class OnnxPolicyRuntime(PolicyRuntime):
         try:
             import onnxruntime as ort
         except ImportError as error:
-            raise RuntimeError("ONNX policy support requires the 'motrix-deploy[onnx]' extra") from error
+            raise RuntimeError(
+                "onnxruntime is missing; it is a core dependency of motrix-deploy, so reinstall the environment"
+            ) from error
         self._input_spec = input_spec
         self._output_spec = output_spec
         self._session = ort.InferenceSession(

--- a/motrix_deploy_tasks/README.md
+++ b/motrix_deploy_tasks/README.md
@@ -10,7 +10,7 @@ The default sim2sim recipe targets `go2-walk-rough`; the default sim2real recipe
 workspace config path with:
 
 ```bash
-uv run motrix-deploy sim2sim \
+motrix-deploy sim2sim \
   --config-name go2_walk_flat_sim2sim \
   artifact=artifacts/go2-walk-flat.deploy
 ```

--- a/motrix_deploy_tasks/pyproject.toml
+++ b/motrix_deploy_tasks/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-onnx = ["motrix-deploy[onnx]"]
 mujoco = ["motrix-deploy-mujoco"]
 unitree = ["motrix-deploy-unitree"]
 

--- a/motrix_deploy_unitree/README.md
+++ b/motrix_deploy_unitree/README.md
@@ -7,7 +7,7 @@ physical backend is opened.
 The SDK is installed from the pinned Motphys-maintained fork as part of the normal workspace sync:
 
 ```bash
-uv sync --all-packages --all-groups --all-extras
+sh install.sh --all
 ```
 
 The Motphys fork includes the CRC shared libraries in built distributions. The SDK metadata declares
@@ -72,7 +72,7 @@ with no publisher, use `motrix-deploy-unitree read-lowstate <network-interface>`
 Use the read-only diagnostic before enabling any command path:
 
 ```bash
-uv run motrix-deploy-unitree read-lowstate enp5s0
+motrix-deploy-unitree read-lowstate enp5s0
 ```
 
 It subscribes to `rt/lowstate` for 10 seconds by default and prints at most one sample every 0.5 seconds. It does not need
@@ -96,7 +96,7 @@ transport troubleshooting. The command returns `0` after receiving a valid frame
 The packaged helper requires a frozen deployment artifact as its robot, gain, timing, and limit contract:
 
 ```bash
-uv run motrix-deploy-unitree joint-control \
+motrix-deploy-unitree joint-control \
   enp5s0 \
   FL_thigh_joint \
   0.9 \
@@ -112,7 +112,7 @@ state timeout and the remote Select emergency stop remain active.
 
 Use `--move-duration`, `--hold-duration`, and `--return-duration` to change the default `2.0`, `1.0`, and `2.0` second
 phases. Setting `--return-duration 0` skips the return trajectory, but closing still changes all joints to damping mode.
-Run `uv run motrix-deploy-unitree joint-control --help` for the complete command reference. Although the
+Run `motrix-deploy-unitree joint-control --help` for the complete command reference. Although the
 helper changes one target, each Unitree `LowCmd` necessarily contains commands for all 12 joints.
 
 ## Policy gain overrides
@@ -125,7 +125,7 @@ default-pose transition and policy commands; damping stop still uses `kp=0` and 
 From the repository root:
 
 ```bash
-uv run motrix-deploy sim2real \
+motrix-deploy sim2real \
   artifact=artifacts/go2-walk-rough.deploy \
   backend.network_interface=enp5s0 \
   hardware.confirm=true

--- a/motrix_rl/README.md
+++ b/motrix_rl/README.md
@@ -5,18 +5,19 @@ interfaces. Concrete providers currently support SKRL PPO with JAX or PyTorch, R
 FastSAC implementation.
 
 Environment-specific training presets live under `configs/task/`, while shared provider defaults live under
-`configs/algo_base/`. From the workspace root, select a preset with Hydra's `task=<env-id>/<method>` syntax:
+`configs/algo_base/`. From the workspace root, select a preset with Hydra's `task=<env-id>/<method>` syntax (run from the
+activated workspace environment, `source .venv/bin/activate`):
 
 ```bash
-uv run scripts/train.py task=cartpole/skrl.ppo
-uv run scripts/train.py task=cartpole/rslrl.ppo
-uv run scripts/train.py task=g1-walk-rough/motrix.fastsac
+python scripts/train.py task=cartpole/skrl.ppo
+python scripts/train.py task=cartpole/rslrl.ppo
+python scripts/train.py task=g1-walk-rough/motrix.fastsac
 ```
 
 Install the extra required by the selected provider before training:
 
 ```bash
-uv sync --all-packages --extra skrl-jax
-uv sync --all-packages --extra skrl-torch
-uv sync --all-packages --extra rslrl
+sh install.sh --skrl-jax   # JAX (Linux only)
+sh install.sh --skrl-torch # PyTorch (default)
+sh install.sh --rslrl      # RSLRL (PyTorch only)
 ```

--- a/motrix_rl/pyproject.toml
+++ b/motrix_rl/pyproject.toml
@@ -21,13 +21,16 @@ dependencies = [
     "numpy>=1.26",
     "omegaconf>=2.3,<2.4",
     "nvidia-ml-py>=13.610.43",
-    # Default training backend; also required by scripts/view.py. Resolved
-    # from the pytorch-cu128 index via the workspace root tool.uv.sources.
-    "torch==2.7.0",
+    # ONNX export of trained policies; onnxruntime (for the parity check and
+    # deployment inference) comes in via motrix-deploy.
+    "onnx==1.20.1",
+    # Default training backend; also required by scripts/view.py. The exact
+    # version and wheel index are chosen by the workspace root `cuda`/`rocm`
+    # extras (see the root pyproject.toml tool.uv.sources).
+    "torch>=2.7,<3",
 ]
 
 [project.optional-dependencies]
-onnx = ["onnx==1.20.1", "onnxruntime==1.23.2"]
 skrl-jax = [
     "skrl>=2.1,<2.2; sys_platform == 'linux'",
     "jax[cuda12]==0.4.34; sys_platform == 'linux'",
@@ -36,15 +39,9 @@ skrl-jax = [
 ]
 skrl-torch = [
     "skrl>=2.1,<2.2",
-    "torch==2.7.0",
-    "torchvision==0.22.0",
-    "torchaudio==2.7.0",
+    "torch>=2.7,<3",
 ]
 rslrl = [
-    "motrix-deploy[onnx]",
-    "onnx==1.20.1",
     "rsl-rl-lib>=4.0,<5.0",
-    "torch==2.7.0",
-    "torchvision==0.22.0",
-    "torchaudio==2.7.0",
+    "torch>=2.7,<3",
 ]

--- a/motrix_rl/src/motrix_rl/system_metrics.py
+++ b/motrix_rl/src/motrix_rl/system_metrics.py
@@ -5,8 +5,8 @@
 
 CPU samplers read Linux ``/proc`` interfaces and return ``None`` where they
 are unavailable, so panels degrade to ``n/a`` fields; memory sampling also
-supports Windows via ``GlobalMemoryStatusEx``. The GPU samplers use NVML,
-which works on any platform with an NVIDIA driver.
+supports Windows via ``GlobalMemoryStatusEx``. GPU samplers use NVML on
+NVIDIA hosts and AMD SMI on ROCm hosts.
 """
 
 from __future__ import annotations
@@ -192,6 +192,22 @@ class MemoryUsageSampler:
 # NVML reads the same counters nvidia-smi reports, but in-process at
 # microsecond cost instead of a subprocess spawn per query.
 _nvml_state: tuple[Any, list[Any]] | tuple[()] | None = None  # None: untried; (): unavailable
+_amd_smi_state: tuple[Any, list[Any]] | tuple[()] | None = None
+_amd_activity_supported: bool | None = None
+
+
+def _amd_smi() -> tuple[Any, list[Any]] | None:
+    """Lazily initialize AMD SMI, returning ``(module, processor_handles)``."""
+    global _amd_smi_state
+    if _amd_smi_state is None:
+        try:
+            import amdsmi
+
+            amdsmi.amdsmi_init()
+            _amd_smi_state = (amdsmi, amdsmi.amdsmi_get_processor_handles())
+        except Exception:
+            _amd_smi_state = ()
+    return _amd_smi_state or None
 
 
 def _nvml() -> tuple[Any, list[Any]] | None:
@@ -210,9 +226,20 @@ def _nvml() -> tuple[Any, list[Any]] | None:
 
 
 class GpuMemoryUsageSampler:
-    """Read aggregate NVIDIA memory usage across all visible GPUs via NVML."""
+    """Read aggregate accelerator memory via AMD SMI or NVML."""
 
     def sample(self) -> MemoryUsage | None:
+        session = _amd_smi()
+        if session is not None:
+            amdsmi, devices = session
+            used = total = 0
+            try:
+                for device in devices:
+                    used += int(amdsmi.amdsmi_get_gpu_memory_usage(device, amdsmi.AmdSmiMemoryType.VRAM))
+                    total += int(amdsmi.amdsmi_get_gpu_memory_total(device, amdsmi.AmdSmiMemoryType.VRAM))
+            except Exception:
+                return None
+            return MemoryUsage(used_bytes=used, total_bytes=total) if total > 0 else None
         session = _nvml()
         if session is None:
             return None
@@ -229,9 +256,31 @@ class GpuMemoryUsageSampler:
 
 
 class GpuUtilizationSampler:
-    """Read aggregate NVIDIA GPU utilization across all visible GPUs via NVML."""
+    """Read aggregate accelerator utilization via AMD SMI or NVML."""
 
     def sample(self) -> float | None:
+        global _amd_activity_supported
+        session = _amd_smi()
+        if session is not None:
+            amdsmi, devices = session
+            values: list[float] = []
+            if _amd_activity_supported is not False:
+                try:
+                    for device in devices:
+                        activity = amdsmi.amdsmi_get_gpu_activity(device)
+                        value = activity.get("gfx_activity", activity.get("gpu_busy_percent"))
+                        if value is not None:
+                            values.append(float(value))
+                except Exception:
+                    _amd_activity_supported = False
+            if _amd_activity_supported is False:
+                # Some integrated AMD GPUs (including Radeon 890M) expose
+                # VRAM through AMD SMI but return AMDSMI_STATUS_UNEXPECTED_DATA
+                # for ``amdsmi_get_gpu_activity``.  The kernel's DRM sysfs
+                # counter is available on those devices and reports the same
+                # busy percentage used by rocm-smi.
+                values = _sysfs_gpu_busy_percent()
+            return sum(values) / len(values) if values else None
         session = _nvml()
         if session is None:
             return None
@@ -243,3 +292,18 @@ class GpuUtilizationSampler:
         except pynvml.NVMLError:
             return None
         return sum(values) / len(values) if values else None
+
+
+def _sysfs_gpu_busy_percent() -> list[float]:
+    """Read AMD DRM GPU busy counters as a fallback for unsupported SMI APIs."""
+    if sys.platform == "win32":
+        return []
+    values: list[float] = []
+    for path in Path("/sys/class/drm").glob("card*/device/gpu_busy_percent"):
+        try:
+            value = float(path.read_text().strip())
+        except (OSError, ValueError):
+            continue
+        if 0.0 <= value <= 100.0:
+            values.append(value)
+    return values

--- a/motrix_rl/tests/test_system_metrics.py
+++ b/motrix_rl/tests/test_system_metrics.py
@@ -65,6 +65,9 @@ def _fake_nvml(monkeypatch, handles, utilization, memory, error=None) -> None:
         nvmlDeviceGetMemoryInfo=memory_info,
         NVMLError=RuntimeError,
     )
+    # The samplers prefer AMD SMI; pin it off so these tests exercise the
+    # NVML backend on AMD hosts too, where a real session would win.
+    monkeypatch.setattr(system_metrics, "_amd_smi_state", ())
     monkeypatch.setattr(system_metrics, "_nvml_state", (fake_pynvml, handles))
 
 
@@ -95,11 +98,118 @@ def test_gpu_samplers_return_none_on_nvml_error(monkeypatch) -> None:
     assert GpuMemoryUsageSampler().sample() is None
 
 
+def _fake_amdsmi(monkeypatch, handles, utilization, memory) -> None:
+    """Install a fake ``(amdsmi, handles)`` session with per-handle metric tables."""
+
+    def gpu_activity(handle):
+        return {"gfx_activity": utilization[handle]}
+
+    def gpu_memory_usage(handle, memory_type):
+        return memory[handle][0]
+
+    def gpu_memory_total(handle, memory_type):
+        return memory[handle][1]
+
+    fake_amdsmi = types.SimpleNamespace(
+        amdsmi_get_gpu_activity=gpu_activity,
+        amdsmi_get_gpu_memory_usage=gpu_memory_usage,
+        amdsmi_get_gpu_memory_total=gpu_memory_total,
+        AmdSmiMemoryType=types.SimpleNamespace(VRAM="vram"),
+    )
+    # Pin NVML off so the AMD SMI backend is exercised on every host.
+    monkeypatch.setattr(system_metrics, "_nvml_state", ())
+    monkeypatch.setattr(system_metrics, "_amd_activity_supported", None)
+    monkeypatch.setattr(system_metrics, "_amd_smi_state", (fake_amdsmi, handles))
+
+
+def test_gpu_samplers_aggregate_via_amdsmi_backend(monkeypatch) -> None:
+    handles = ["gpu0", "gpu1"]
+    _fake_amdsmi(
+        monkeypatch,
+        handles,
+        utilization={"gpu0": 10, "gpu1": 30},
+        memory={"gpu0": (100 * 1024**2, 200 * 1024**2), "gpu1": (300 * 1024**2, 400 * 1024**2)},
+    )
+
+    assert GpuUtilizationSampler().sample() == 20.0
+    assert GpuMemoryUsageSampler().sample() == MemoryUsage(used_bytes=400 * 1024**2, total_bytes=600 * 1024**2)
+
+
 def test_gpu_samplers_return_none_without_nvml(monkeypatch) -> None:
+    monkeypatch.setattr(system_metrics, "_amd_smi_state", ())
     monkeypatch.setattr(system_metrics, "_nvml_state", ())
 
     assert GpuUtilizationSampler().sample() is None
     assert GpuMemoryUsageSampler().sample() is None
+
+
+def _patch_sysfs_gpu_busy(monkeypatch, entries) -> None:
+    """Serve ``entries`` (text or Exception) as DRM ``gpu_busy_percent`` files."""
+
+    class _SysfsFile:
+        def __init__(self, payload) -> None:
+            self._payload = payload
+
+        def read_text(self) -> str:
+            if isinstance(self._payload, Exception):
+                raise self._payload
+            return self._payload
+
+    monkeypatch.setattr(system_metrics.Path, "glob", lambda self, pattern: iter(_SysfsFile(entry) for entry in entries))
+
+
+def test_sysfs_gpu_busy_percent_reads_valid_counters(monkeypatch) -> None:
+    _patch_sysfs_gpu_busy(monkeypatch, ["12\n", "34\n"])
+
+    assert system_metrics._sysfs_gpu_busy_percent() == [12.0, 34.0]
+
+
+def test_sysfs_gpu_busy_percent_skips_invalid_and_unreadable_counters(monkeypatch) -> None:
+    _patch_sysfs_gpu_busy(monkeypatch, ["120\n", "-5\n", "n/a\n", OSError("denied"), "55\n"])
+
+    assert system_metrics._sysfs_gpu_busy_percent() == [55.0]
+
+
+def test_sysfs_gpu_busy_percent_returns_nothing_on_windows(monkeypatch) -> None:
+    monkeypatch.setattr(sys, "platform", "win32")
+    glob_called = False
+
+    def fail_glob(pattern):
+        nonlocal glob_called
+        glob_called = True
+        return iter(())
+
+    monkeypatch.setattr(system_metrics.Path, "glob", fail_glob)
+
+    assert system_metrics._sysfs_gpu_busy_percent() == []
+    assert not glob_called
+
+
+def test_gpu_utilization_sampler_falls_back_to_sysfs_when_amdsmi_activity_unsupported(monkeypatch) -> None:
+    handles = ["gpu0", "gpu1"]
+
+    def gpu_activity(handle):
+        raise RuntimeError("AMDSMI_STATUS_UNEXPECTED_DATA")
+
+    memory = {"gpu0": (1, 2), "gpu1": (3, 4)}
+    fake_amdsmi = types.SimpleNamespace(
+        amdsmi_get_gpu_activity=gpu_activity,
+        amdsmi_get_gpu_memory_usage=lambda handle, memory_type: memory[handle][0],
+        amdsmi_get_gpu_memory_total=lambda handle, memory_type: memory[handle][1],
+        AmdSmiMemoryType=types.SimpleNamespace(VRAM="vram"),
+    )
+    monkeypatch.setattr(system_metrics, "_nvml_state", ())
+    monkeypatch.setattr(system_metrics, "_amd_activity_supported", None)
+    monkeypatch.setattr(system_metrics, "_amd_smi_state", (fake_amdsmi, handles))
+    _patch_sysfs_gpu_busy(monkeypatch, ["20\n", "60\n"])
+
+    assert GpuUtilizationSampler().sample() == 40.0
+
+    # The failure is latched, so later samples keep reading sysfs instead of
+    # retrying the unsupported AMD SMI activity API on every call.
+    monkeypatch.setattr(system_metrics.Path, "glob", lambda self, pattern: iter([]))
+
+    assert GpuUtilizationSampler().sample() is None
 
 
 def test_memory_usage_sampler_reads_proc_meminfo(tmp_path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,24 @@ docs = [
     "sphinx-design",
     "tensorboard==2.20.0",
 ]
+# Mutually exclusive GPU wheel profiles: `cuda` pulls the NVIDIA wheels from
+# the pytorch-cu128 index, `rocm` the AMD wheels from the pytorch-rocm72
+# index. Select exactly one with `uv sync --extra cuda` or
+# `uv sync --extra rocm`; the extras are declared conflicting so uv keeps
+# both branches in the single uv.lock. Without any extra, torch resolves
+# from the default index (PyPI).
+cuda = [
+    "torch==2.7.0; sys_platform == 'linux' or sys_platform == 'win32'",
+    "torchvision==0.22.0; sys_platform == 'linux' or sys_platform == 'win32'",
+    "torchaudio==2.7.0; sys_platform == 'linux' or sys_platform == 'win32'",
+]
+# ROCm wheels only exist for Linux x86_64; the markers keep other platforms
+# from resolving these requirements against the default (PyPI) index.
+rocm = [
+    "amdsmi; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "torch==2.11.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
+    "triton-rocm==3.6.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
+]
 
 [dependency-groups]
 dev = [
@@ -41,9 +59,7 @@ dev = [
 test = [
     { include-group = "dev" },
     "hydra-core>=1.3,<1.4",
-    "motrix-deploy[onnx]",
     "motrix-deploy-unitree",
-    "onnx==1.20.1",
 ]
 
 [tool.uv.workspace]
@@ -59,9 +75,27 @@ members = [
     "motrix_rl",
 ]
 
+[tool.uv]
+package = false
+prerelease = "if-necessary-or-explicit"
+# `cuda` and `rocm` resolve torch from different indexes and can never be
+# installed together; declaring them conflicting lets uv keep both branches
+# (as separate forks) in the same uv.lock.
+conflicts = [
+    [
+        { extra = "cuda" },
+        { extra = "rocm" },
+    ],
+]
+
 [[tool.uv.index]]
 name = "pytorch-cu128"
 url = "https://download.pytorch.org/whl/cu128"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-rocm72"
+url = "https://download.pytorch.org/whl/rocm7.2"
 explicit = true
 
 [[tool.uv.index]]
@@ -78,8 +112,13 @@ motrix-env-motrixsim = { workspace = true }
 motrix-env-mujoco = { workspace = true }
 motrix-envs = { workspace = true }
 motrix-rl = { workspace = true }
+# The `extra = "rocm"` entry routes torch requirements declared in the rocm
+# extra to the ROCm index; the `extra = "cuda"` entry does the same for the
+# cuda extra. Requirements outside both extras (bare sync) fall back to the
+# default index.
 torch = [
-    { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'", extra = "cuda" },
+    { index = "pytorch-rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'", extra = "rocm" },
 ]
 torchvision = [
     { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
@@ -87,10 +126,9 @@ torchvision = [
 torchaudio = [
     { index = "pytorch-cu128", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
-
-[tool.uv]
-package = false
-prerelease = "if-necessary-or-explicit"
+triton-rocm = [
+    { index = "pytorch-rocm72", marker = "sys_platform == 'linux' and platform_machine == 'x86_64'" },
+]
 
 [tool.mypy]
 files = [

--- a/uv.lock
+++ b/uv.lock
@@ -2,12 +2,18 @@ version = 1
 revision = 3
 requires-python = "==3.10.*"
 resolution-markers = [
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
-    "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "sys_platform == 'darwin'",
-    "sys_platform == 'win32'",
+    "platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm'",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')",
+    "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm'",
+    "(platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')",
+    "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm'",
+    "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm'",
+    "extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm'",
 ]
+conflicts = [[
+    { package = "motrix-lab", extra = "cuda" },
+    { package = "motrix-lab", extra = "rocm" },
+]]
 
 [manifest]
 members = [
@@ -54,6 +60,15 @@ wheels = [
 ]
 
 [[package]]
+name = "amdsmi"
+version = "7.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/c1/330da195623ec7d9f699be2dbec98df364b1def9b48aa169f1abe369804f/amdsmi-7.0.2.tar.gz", hash = "sha256:3e622e48c630b889045a6f57387455cdf082066348718172dd8af6d275baf8f2", size = 61577, upload-time = "2025-10-11T05:17:44.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/cf/bacc741d9926d662e76fd694f5bc63dd4c2471e32cedfb1c3cca7e47aa3c/amdsmi-7.0.2-py3-none-any.whl", hash = "sha256:db5aa757f8ed82dfd799c4d39e2828542678dc4e485b0ab7fabe5f398fec5652", size = 64366, upload-time = "2025-10-11T05:17:44.047Z" },
+]
+
+[[package]]
 name = "antlr4-python3-runtime"
 version = "4.9.3"
 source = { registry = "https://pypi.org/simple" }
@@ -73,8 +88,8 @@ name = "astunparse"
 version = "1.6.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "sys_platform == 'linux'" },
-    { name = "wheel", marker = "sys_platform == 'linux'" },
+    { name = "six", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "wheel", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872", size = 18290, upload-time = "2019-12-22T18:12:13.129Z" }
 wheels = [
@@ -154,12 +169,12 @@ name = "chex"
 version = "0.1.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "sys_platform == 'linux'" },
-    { name = "jax", marker = "sys_platform == 'linux'" },
-    { name = "jaxlib", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "toolz", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "absl-py", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jax", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jaxlib", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "toolz", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/77/70/53c7d404ce9e2a94009aea7f77ef6e392f6740e071c62683a506647c520f/chex-0.1.90.tar.gz", hash = "sha256:d3c375aeb6154b08f1cccd2bee4ed83659ee2198a6acf1160d2fe2e4a6c87b5c", size = 92363, upload-time = "2025-07-23T19:50:47.945Z" }
 wheels = [
@@ -171,7 +186,7 @@ name = "click"
 version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
@@ -237,6 +252,70 @@ toml = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder", marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/1f/5ef51f5fbaa5d4d3201bb3d7555af028ec1aa4416275ccbf73c9e34e3d2d/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9851b0caa8bfd3bc6fa054eaf57bea7c8e9c3a62db2d2621224677f49f3c53d0", size = 6675244, upload-time = "2026-05-29T23:11:38.664Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/64/bb17e4d168569ef7be05c44474fe3dc19278d60a69ba228e45a431c86444/cuda_bindings-13.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:c0c4b1a995098c46695c24257a342dc97d6e6d3f3050b944c9f43bd26d734051", size = 5625597, upload-time = "2026-05-29T23:11:40.808Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.8.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/e6/22df83f82f9bc26cb1c42265cf14d34d4908dba2a0f261bd7b28244acb00/cuda_pathfinder-1.8.1-py3-none-any.whl", hash = "sha256:ae0137ff9e56ea97499bcbf54f5f2778ec25f3266715ac86da192a795af982a8", size = 62552, upload-time = "2026-09-02T16:55:28.64Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.2"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/b2/453099f5f3b698d7d0eab38916aac44c7f76229f451709e2eb9db6615dcd/cuda_toolkit-13.0.2-py2.py3-none-any.whl", hash = "sha256:b198824cf2f54003f50d64ada3a0f184b42ca0846c1c94192fa269ecd97a66eb", size = 2364, upload-time = "2025-12-19T23:24:07.328Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+cusolver = [
+    { name = "nvidia-cusolver", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+
+[[package]]
 name = "cyclonedds"
 version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
@@ -292,7 +371,7 @@ epath = [
     { name = "zipp" },
 ]
 epy = [
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 
 [[package]]
@@ -339,15 +418,15 @@ name = "flax"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jax", marker = "sys_platform == 'linux'" },
-    { name = "msgpack", marker = "sys_platform == 'linux'" },
-    { name = "optax", marker = "sys_platform == 'linux'" },
-    { name = "orbax-checkpoint", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
-    { name = "rich", marker = "sys_platform == 'linux'" },
-    { name = "tensorstore", marker = "sys_platform == 'linux'" },
-    { name = "treescope", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "jax", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "msgpack", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "optax", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "orbax-checkpoint", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "pyyaml", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "rich", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "tensorstore", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "treescope", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/45/5d/6fa18b5dcb737f0c454ad3c116c4faebbb51f164d81109255391a0462c5e/flax-0.10.4.tar.gz", hash = "sha256:57ae44d3f111fc85cff9049adb9684ce8ebd44e87bd8ca776ed52422c2d85021", size = 5179580, upload-time = "2025-02-27T00:11:00.913Z" }
 wheels = [
@@ -417,7 +496,7 @@ name = "google-pasta"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "six", marker = "sys_platform == 'linux'" },
+    { name = "six", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/4a/0bd53b36ff0323d10d5f24ebd67af2de10a1117f5cf4d7add90df92756f1/google-pasta-0.2.0.tar.gz", hash = "sha256:c9f2c8dfc8f96d0d5808299920721be30c9eec37f2389f28904f454565c8a16e", size = 40430, upload-time = "2020-03-13T18:57:50.34Z" }
 wheels = [
@@ -465,14 +544,17 @@ name = "h5py"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/4d/6a/0d79de0b025aa85dc8864de8e97659c94cf3d23148394a954dc5ca52f8c8/h5py-3.15.1.tar.gz", hash = "sha256:c86e3ed45c4473564de55aa83b6fc9e5ead86578773dfbd93047380042e26b69", size = 426236, upload-time = "2025-10-16T10:35:27.404Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/30/8fa61698b438dd751fa46a359792e801191dadab560d0a5f1c709443ef8e/h5py-3.15.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:67e59f6c2f19a32973a40f43d9a088ae324fe228c8366e25ebc57ceebf093a6b", size = 3414477, upload-time = "2025-10-16T10:33:24.201Z" },
+    { url = "https://files.pythonhosted.org/packages/16/16/db2f63302937337c4e9e51d97a5984b769bdb7488e3d37632a6ac297f8ef/h5py-3.15.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0e2f471688402c3404fa4e13466e373e622fd4b74b47b56cfdff7cc688209422", size = 2850298, upload-time = "2025-10-16T10:33:27.747Z" },
     { url = "https://files.pythonhosted.org/packages/fc/2e/f1bb7de9b05112bfd14d5206090f0f92f1e75bbb412fbec5d4653c3d44dd/h5py-3.15.1-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4c45802bcb711e128a6839cb6c01e9ac648dc55df045c9542a675c771f15c8d5", size = 4523605, upload-time = "2025-10-16T10:33:31.168Z" },
     { url = "https://files.pythonhosted.org/packages/05/8a/63f4b08f3628171ce8da1a04681a65ee7ac338fde3cb3e9e3c9f7818e4da/h5py-3.15.1-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:64ce3f6470adb87c06e3a8dd1b90e973699f1759ad79bfa70c230939bff356c9", size = 4735346, upload-time = "2025-10-16T10:33:34.759Z" },
     { url = "https://files.pythonhosted.org/packages/74/48/f16d12d9de22277605bcc11c0dcab5e35f06a54be4798faa2636b5d44b3c/h5py-3.15.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:4411c1867b9899a25e983fff56d820a66f52ac326bbe10c7cdf7d832c9dcd883", size = 4175305, upload-time = "2025-10-16T10:33:38.83Z" },
     { url = "https://files.pythonhosted.org/packages/d6/2f/47cdbff65b2ce53c27458c6df63a232d7bb1644b97df37b2342442342c84/h5py-3.15.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:2cbc4104d3d4aca9d6db8c0c694555e255805bfeacf9eb1349bda871e26cacbe", size = 4653602, upload-time = "2025-10-16T10:33:42.188Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/28/dc08de359c2f43a67baa529cb70d7f9599848750031975eed92d6ae78e1d/h5py-3.15.1-cp310-cp310-win_amd64.whl", hash = "sha256:01f55111ca516f5568ae7a7fc8247dfce607de331b4467ee8a9a6ed14e5422c7", size = 2873601, upload-time = "2025-10-16T10:33:45.323Z" },
 ]
 
 [[package]]
@@ -480,7 +562,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "sys_platform == 'win32' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -590,11 +672,11 @@ name = "jax"
 version = "0.4.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jaxlib", marker = "sys_platform == 'linux'" },
-    { name = "ml-dtypes", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "opt-einsum", marker = "sys_platform == 'linux'" },
-    { name = "scipy", marker = "sys_platform == 'linux'" },
+    { name = "jaxlib", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "ml-dtypes", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "opt-einsum", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "scipy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/19/6a/cacfcdf77841a4562e555ef35e0dbc5f8ca79c9f1010aaa4cf3973e79c69/jax-0.4.34.tar.gz", hash = "sha256:44196854f40c5f9cea3142824b9f1051f85afc3fcf7593ec5479fc8db01c58db", size = 1848472, upload-time = "2024-10-04T14:37:12.698Z" }
 wheels = [
@@ -603,8 +685,8 @@ wheels = [
 
 [package.optional-dependencies]
 cuda12 = [
-    { name = "jax-cuda12-plugin", extra = ["with-cuda"], marker = "sys_platform == 'linux'" },
-    { name = "jaxlib", marker = "sys_platform == 'linux'" },
+    { name = "jax-cuda12-plugin", extra = ["with-cuda"], marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jaxlib", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 
 [[package]]
@@ -621,7 +703,7 @@ name = "jax-cuda12-plugin"
 version = "0.4.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jax-cuda12-pjrt", marker = "sys_platform == 'linux'" },
+    { name = "jax-cuda12-pjrt", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/d7/149043aad22811f11ae5339fcfd3ce9176cf00a09cc05d6a0e4d3a3f7e8a/jax_cuda12_plugin-0.4.34-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:1b037a408b9d9de59367c9513a9445b705da526657a0c4d593e84234312261e7", size = 14884290, upload-time = "2024-10-04T14:39:36.188Z" },
@@ -630,16 +712,16 @@ wheels = [
 
 [package.optional-dependencies]
 with-cuda = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cuda-nvcc-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cudnn-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cufft-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusolver-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 
 [[package]]
@@ -647,13 +729,16 @@ name = "jaxlib"
 version = "0.4.34"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "scipy", marker = "sys_platform == 'linux'" },
+    { name = "ml-dtypes", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "scipy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/31/2e254fe2fc23201775a7d0ccd1bcde892cfa349eb805744b81b15e0dcf74/jaxlib-0.4.34-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:b7a212a3cb5c6acc201c32ae4f4b5f5a9ac09457fbb77ba8db5ce7e7d4adc214", size = 87399257, upload-time = "2024-10-04T14:37:26.654Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/67/6a344c357caad33e84b871925cd043b4218fc13a427266d1a1dedcb1c095/jaxlib-0.4.34-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:45d719a2ce0ebf21255a277b71d756f3609b7b5be70cddc5d88fd58c35219de0", size = 67617952, upload-time = "2024-10-04T14:37:32.393Z" },
     { url = "https://files.pythonhosted.org/packages/dd/ea/12c836126419ca80248228f2236831617eedb1e3640c34c942606f33bb08/jaxlib-0.4.34-cp310-cp310-manylinux2014_aarch64.whl", hash = "sha256:3e60bc826933082e99b19b87c21818a8d26fcdb01f418d47cedff554746fd6cc", size = 69391770, upload-time = "2024-10-04T14:37:38.448Z" },
     { url = "https://files.pythonhosted.org/packages/e4/b0/a5bd34643c070e50829beec217189eab1acdfea334df1f9ddb4e5f8bec0f/jaxlib-0.4.34-cp310-cp310-manylinux2014_x86_64.whl", hash = "sha256:d840e64b85f8865404d6d225b9bb340e158df1457152a361b05680e24792b232", size = 86094116, upload-time = "2024-10-04T14:37:44.001Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c9/35a4233fe74ddd5aabe89aac1b3992b0e463982564252d21fd263d4d9992/jaxlib-0.4.34-cp310-cp310-win_amd64.whl", hash = "sha256:b0001c8f0e2b1c7bc99e4f314b524a340d25653505c1a1484d4041a9d3617f6f", size = 55206389, upload-time = "2024-10-04T14:37:49.673Z" },
 ]
 
 [[package]]
@@ -673,14 +758,14 @@ name = "keras"
 version = "3.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "sys_platform == 'linux'" },
-    { name = "h5py", marker = "sys_platform == 'linux'" },
-    { name = "ml-dtypes", marker = "sys_platform == 'linux'" },
-    { name = "namex", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "optree", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "rich", marker = "sys_platform == 'linux'" },
+    { name = "absl-py", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "h5py", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "ml-dtypes", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "namex", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "optree", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "packaging", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "rich", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9b/b8/8df141314a64a31d3a21762658826f716cdf4c261c7fcdb3f729958def55/keras-3.12.0.tar.gz", hash = "sha256:536e3f8385a05ae04e82e08715a1a59988578087e187b04cb0a6fad11743f07f", size = 1129187, upload-time = "2025-10-27T20:23:11.574Z" }
 wheels = [
@@ -693,10 +778,15 @@ version = "18.1.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6e/5c/ca35e19a4f142adffa27e3d652196b7362fa612243e2b916845d801454fc/libclang-18.1.1.tar.gz", hash = "sha256:a1214966d08d73d971287fc3ead8dfaf82eb07fb197680d8b3859dbbbbf78250", size = 39612, upload-time = "2024-03-17T16:04:37.434Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/49/f5e3e7e1419872b69f6f5e82ba56e33955a74bd537d8a1f5f1eff2f3668a/libclang-18.1.1-1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:0b2e143f0fac830156feb56f9231ff8338c20aecfe72b4ffe96f19e5a1dbb69a", size = 25836045, upload-time = "2024-06-30T17:40:31.646Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/e5/fc61bbded91a8830ccce94c5294ecd6e88e496cc85f6704bf350c0634b70/libclang-18.1.1-py2.py3-none-macosx_10_9_x86_64.whl", hash = "sha256:6f14c3f194704e5d09769108f03185fce7acaf1d1ae4bbb2f30a72c2400cb7c5", size = 26502641, upload-time = "2024-03-18T15:52:26.722Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/1df62b44db2583375f6a8a5e2ca5432bbdc3edb477942b9b7c848c720055/libclang-18.1.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:83ce5045d101b669ac38e6da8e58765f12da2d3aafb3b9b98d88b286a60964d8", size = 26420207, upload-time = "2024-03-17T15:00:26.63Z" },
     { url = "https://files.pythonhosted.org/packages/1d/fc/716c1e62e512ef1c160e7984a73a5fc7df45166f2ff3f254e71c58076f7c/libclang-18.1.1-py2.py3-none-manylinux2010_x86_64.whl", hash = "sha256:c533091d8a3bbf7460a00cb6c1a71da93bffe148f172c7d03b1c31fbf8aa2a0b", size = 24515943, upload-time = "2024-03-17T16:03:45.942Z" },
     { url = "https://files.pythonhosted.org/packages/3c/3d/f0ac1150280d8d20d059608cf2d5ff61b7c3b7f7bcf9c0f425ab92df769a/libclang-18.1.1-py2.py3-none-manylinux2014_aarch64.whl", hash = "sha256:54dda940a4a0491a9d1532bf071ea3ef26e6dbaf03b5000ed94dd7174e8f9592", size = 23784972, upload-time = "2024-03-17T16:12:47.677Z" },
     { url = "https://files.pythonhosted.org/packages/fe/2f/d920822c2b1ce9326a4c78c0c2b4aa3fde610c7ee9f631b600acb5376c26/libclang-18.1.1-py2.py3-none-manylinux2014_armv7l.whl", hash = "sha256:cf4a99b05376513717ab5d82a0db832c56ccea4fd61a69dbb7bccf2dfb207dbe", size = 20259606, upload-time = "2024-03-17T16:17:42.437Z" },
     { url = "https://files.pythonhosted.org/packages/2d/c2/de1db8c6d413597076a4259cea409b83459b2db997c003578affdd32bf66/libclang-18.1.1-py2.py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:69f8eb8f65c279e765ffd28aaa7e9e364c776c17618af8bff22a8df58677ff4f", size = 24921494, upload-time = "2024-03-17T16:14:20.132Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/2d/3f480b1e1d31eb3d6de5e3ef641954e5c67430d5ac93b7fa7e07589576c7/libclang-18.1.1-py2.py3-none-win_amd64.whl", hash = "sha256:4dd2d3b82fab35e2bf9ca717d7b63ac990a3519c7e312f19fa8e86dcc712f7fb", size = 26415083, upload-time = "2024-03-17T16:42:21.703Z" },
+    { url = "https://files.pythonhosted.org/packages/71/cf/e01dc4cc79779cd82d77888a88ae2fa424d93b445ad4f6c02bfc18335b70/libclang-18.1.1-py2.py3-none-win_arm64.whl", hash = "sha256:3f0e1f49f04d3cd198985fea0511576b0aee16f9ff0e0f0cad7f9c57ec3c20e8", size = 22361112, upload-time = "2024-03-17T16:42:59.565Z" },
 ]
 
 [[package]]
@@ -816,10 +906,6 @@ dependencies = [
     { name = "hydra-core" },
     { name = "motrix-env-core" },
     { name = "numpy" },
-]
-
-[package.optional-dependencies]
-onnx = [
     { name = "onnxruntime" },
 ]
 
@@ -828,9 +914,8 @@ requires-dist = [
     { name = "hydra-core", specifier = ">=1.3,<1.4" },
     { name = "motrix-env-core", editable = "motrix_env_core" },
     { name = "numpy", specifier = ">=1.26" },
-    { name = "onnxruntime", marker = "extra == 'onnx'", specifier = "==1.23.2" },
+    { name = "onnxruntime", specifier = "==1.23.2" },
 ]
-provides-extras = ["onnx"]
 
 [[package]]
 name = "motrix-deploy-mujoco"
@@ -865,9 +950,6 @@ dependencies = [
 mujoco = [
     { name = "motrix-deploy-mujoco" },
 ]
-onnx = [
-    { name = "motrix-deploy", extra = ["onnx"] },
-]
 unitree = [
     { name = "motrix-deploy-unitree" },
 ]
@@ -875,13 +957,12 @@ unitree = [
 [package.metadata]
 requires-dist = [
     { name = "motrix-deploy", editable = "motrix_deploy" },
-    { name = "motrix-deploy", extras = ["onnx"], marker = "extra == 'onnx'", editable = "motrix_deploy" },
     { name = "motrix-deploy-mujoco", marker = "extra == 'mujoco'", editable = "motrix_deploy_mujoco" },
     { name = "motrix-deploy-unitree", marker = "extra == 'unitree'", editable = "motrix_deploy_unitree" },
     { name = "motrix-env-core", editable = "motrix_env_core" },
     { name = "numpy", specifier = ">=1.26" },
 ]
-provides-extras = ["onnx", "mujoco", "unitree"]
+provides-extras = ["mujoco", "unitree"]
 
 [[package]]
 name = "motrix-deploy-unitree"
@@ -1004,6 +1085,13 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+cuda = [
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torchaudio", version = "2.7.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'aarch64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_python_implementation != 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torchaudio", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torchvision", version = "0.22.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'aarch64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_python_implementation != 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torchvision", version = "0.22.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
 docs = [
     { name = "autodocsumm" },
     { name = "myst-parser" },
@@ -1015,6 +1103,11 @@ docs = [
     { name = "sphinx-togglebutton" },
     { name = "sphinxcontrib-video" },
     { name = "tensorboard" },
+]
+rocm = [
+    { name = "amdsmi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 unitree = [
     { name = "motrix-deploy-unitree" },
@@ -1030,16 +1123,15 @@ dev = [
 test = [
     { name = "dprint-py" },
     { name = "hydra-core" },
-    { name = "motrix-deploy", extra = ["onnx"] },
     { name = "motrix-deploy-unitree" },
     { name = "mypy" },
-    { name = "onnx" },
     { name = "pytest" },
     { name = "pytest-cov" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "amdsmi", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'" },
     { name = "autodocsumm", marker = "extra == 'docs'" },
     { name = "motrix-deploy", editable = "motrix_deploy" },
     { name = "motrix-deploy-mujoco", editable = "motrix_deploy_mujoco" },
@@ -1058,8 +1150,13 @@ requires-dist = [
     { name = "sphinx-togglebutton", marker = "extra == 'docs'" },
     { name = "sphinxcontrib-video", marker = "extra == 'docs'" },
     { name = "tensorboard", marker = "extra == 'docs'", specifier = "==2.20.0" },
+    { name = "torch", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", specifier = "==2.11.0", index = "https://download.pytorch.org/whl/rocm7.2", conflict = { package = "motrix-lab", extra = "rocm" } },
+    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'cuda') or (sys_platform == 'win32' and extra == 'cuda')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128", conflict = { package = "motrix-lab", extra = "cuda" } },
+    { name = "torchaudio", marker = "(sys_platform == 'linux' and extra == 'cuda') or (sys_platform == 'win32' and extra == 'cuda')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "torchvision", marker = "(sys_platform == 'linux' and extra == 'cuda') or (sys_platform == 'win32' and extra == 'cuda')", specifier = "==0.22.0", index = "https://download.pytorch.org/whl/cu128" },
+    { name = "triton-rocm", marker = "platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'rocm'", specifier = "==3.6.0", index = "https://download.pytorch.org/whl/rocm7.2" },
 ]
-provides-extras = ["unitree", "docs"]
+provides-extras = ["unitree", "docs", "cuda", "rocm"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1071,10 +1168,8 @@ dev = [
 test = [
     { name = "dprint-py", specifier = ">=0.57.0.0" },
     { name = "hydra-core", specifier = ">=1.3,<1.4" },
-    { name = "motrix-deploy", extras = ["onnx"], editable = "motrix_deploy" },
     { name = "motrix-deploy-unitree", editable = "motrix_deploy_unitree" },
     { name = "mypy", specifier = ">=1.15,<2" },
-    { name = "onnx", specifier = "==1.20.1" },
     { name = "pytest", specifier = ">=8.3.3,<8.4.0" },
     { name = "pytest-cov" },
 ]
@@ -1092,46 +1187,32 @@ dependencies = [
     { name = "numpy" },
     { name = "nvidia-ml-py" },
     { name = "omegaconf" },
+    { name = "onnx" },
     { name = "python-abc" },
     { name = "rich" },
-    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 
 [package.optional-dependencies]
-onnx = [
-    { name = "onnx" },
-    { name = "onnxruntime" },
-]
 rslrl = [
-    { name = "motrix-deploy", extra = ["onnx"] },
-    { name = "onnx" },
     { name = "rsl-rl-lib" },
-    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "torchaudio", version = "2.7.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torchaudio", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torchaudio", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "torchvision", version = "0.22.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.22.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torchvision", version = "0.22.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 skrl-jax = [
-    { name = "flax", marker = "sys_platform == 'linux'" },
-    { name = "jax", extra = ["cuda12"], marker = "sys_platform == 'linux'" },
-    { name = "skrl", marker = "sys_platform == 'linux'" },
-    { name = "tensorflow", marker = "sys_platform == 'linux'" },
+    { name = "flax", marker = "sys_platform == 'linux' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jax", extra = ["cuda12"], marker = "sys_platform == 'linux' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "skrl", marker = "sys_platform == 'linux' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "tensorflow", marker = "sys_platform == 'linux' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 skrl-torch = [
     { name = "skrl" },
-    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "torchaudio", version = "2.7.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torchaudio", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torchaudio", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "torchvision", version = "0.22.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.22.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torchvision", version = "0.22.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 
 [package.metadata]
@@ -1141,37 +1222,23 @@ requires-dist = [
     { name = "hydra-core", specifier = ">=1.3,<1.4" },
     { name = "jax", extras = ["cuda12"], marker = "sys_platform == 'linux' and extra == 'skrl-jax'", specifier = "==0.4.34" },
     { name = "motrix-deploy", editable = "motrix_deploy" },
-    { name = "motrix-deploy", extras = ["onnx"], marker = "extra == 'rslrl'", editable = "motrix_deploy" },
     { name = "motrix-env-core", editable = "motrix_env_core" },
     { name = "motrix-env-motrixsim", editable = "motrix_env_motrixsim" },
     { name = "numpy", specifier = ">=1.26" },
     { name = "nvidia-ml-py", specifier = ">=13.610.43" },
     { name = "omegaconf", specifier = ">=2.3,<2.4" },
-    { name = "onnx", marker = "extra == 'onnx'", specifier = "==1.20.1" },
-    { name = "onnx", marker = "extra == 'rslrl'", specifier = "==1.20.1" },
-    { name = "onnxruntime", marker = "extra == 'onnx'", specifier = "==1.23.2" },
+    { name = "onnx", specifier = "==1.20.1" },
     { name = "python-abc", specifier = ">=0.2.0" },
     { name = "rich", specifier = ">=13" },
     { name = "rsl-rl-lib", marker = "extra == 'rslrl'", specifier = ">=4.0,<5.0" },
     { name = "skrl", marker = "sys_platform == 'linux' and extra == 'skrl-jax'", specifier = ">=2.1,<2.2" },
     { name = "skrl", marker = "extra == 'skrl-torch'", specifier = ">=2.1,<2.2" },
     { name = "tensorflow", marker = "sys_platform == 'linux' and extra == 'skrl-jax'", specifier = "==2.20.0" },
-    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32'", specifier = "==2.7.0" },
-    { name = "torch", marker = "sys_platform == 'linux' or sys_platform == 'win32'", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'rslrl') or (sys_platform == 'win32' and extra == 'rslrl')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torch", marker = "(sys_platform == 'linux' and extra == 'skrl-torch') or (sys_platform == 'win32' and extra == 'skrl-torch')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'rslrl'", specifier = "==2.7.0" },
-    { name = "torch", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'skrl-torch'", specifier = "==2.7.0" },
-    { name = "torchaudio", marker = "(sys_platform == 'linux' and extra == 'rslrl') or (sys_platform == 'win32' and extra == 'rslrl')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchaudio", marker = "(sys_platform == 'linux' and extra == 'skrl-torch') or (sys_platform == 'win32' and extra == 'skrl-torch')", specifier = "==2.7.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchaudio", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'rslrl'", specifier = "==2.7.0" },
-    { name = "torchaudio", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'skrl-torch'", specifier = "==2.7.0" },
-    { name = "torchvision", marker = "(sys_platform == 'linux' and extra == 'rslrl') or (sys_platform == 'win32' and extra == 'rslrl')", specifier = "==0.22.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchvision", marker = "(sys_platform == 'linux' and extra == 'skrl-torch') or (sys_platform == 'win32' and extra == 'skrl-torch')", specifier = "==0.22.0", index = "https://download.pytorch.org/whl/cu128" },
-    { name = "torchvision", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'rslrl'", specifier = "==0.22.0" },
-    { name = "torchvision", marker = "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'skrl-torch'", specifier = "==0.22.0" },
+    { name = "torch", specifier = ">=2.7,<3" },
+    { name = "torch", marker = "extra == 'rslrl'", specifier = ">=2.7,<3" },
+    { name = "torch", marker = "extra == 'skrl-torch'", specifier = ">=2.7,<3" },
 ]
-provides-extras = ["onnx", "skrl-jax", "skrl-torch", "rslrl"]
+provides-extras = ["skrl-jax", "skrl-torch", "rslrl"]
 
 [[package]]
 name = "motrixsim"
@@ -1213,10 +1280,14 @@ version = "1.1.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/f5/a2/3b68a9e769db68668b25c6108444a35f9bd163bb848c0650d516761a59c0/msgpack-1.1.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0051fffef5a37ca2cd16978ae4f0aef92f164df86823871b5162812bebecd8e2", size = 81318, upload-time = "2025-10-08T09:14:38.722Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/e1/2b720cc341325c00be44e1ed59e7cfeae2678329fbf5aa68f5bda57fe728/msgpack-1.1.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a605409040f2da88676e9c9e5853b3449ba8011973616189ea5ee55ddbc5bc87", size = 83786, upload-time = "2025-10-08T09:14:40.082Z" },
     { url = "https://files.pythonhosted.org/packages/71/e5/c2241de64bfceac456b140737812a2ab310b10538a7b34a1d393b748e095/msgpack-1.1.2-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b696e83c9f1532b4af884045ba7f3aa741a63b2bc22617293a2c6a7c645f251", size = 398240, upload-time = "2025-10-08T09:14:41.151Z" },
     { url = "https://files.pythonhosted.org/packages/b7/09/2a06956383c0fdebaef5aa9246e2356776f12ea6f2a44bd1368abf0e46c4/msgpack-1.1.2-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:365c0bbe981a27d8932da71af63ef86acc59ed5c01ad929e09a0b88c6294e28a", size = 406070, upload-time = "2025-10-08T09:14:42.821Z" },
     { url = "https://files.pythonhosted.org/packages/0e/74/2957703f0e1ef20637d6aead4fbb314330c26f39aa046b348c7edcf6ca6b/msgpack-1.1.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41d1a5d875680166d3ac5c38573896453bbbea7092936d2e107214daf43b1d4f", size = 393403, upload-time = "2025-10-08T09:14:44.38Z" },
     { url = "https://files.pythonhosted.org/packages/a5/09/3bfc12aa90f77b37322fc33e7a8a7c29ba7c8edeadfa27664451801b9860/msgpack-1.1.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:354e81bcdebaab427c3df4281187edc765d5d76bfb3a7c125af9da7a27e8458f", size = 398947, upload-time = "2025-10-08T09:14:45.56Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/4f/05fcebd3b4977cb3d840f7ef6b77c51f8582086de5e642f3fefee35c86fc/msgpack-1.1.2-cp310-cp310-win32.whl", hash = "sha256:e64c8d2f5e5d5fda7b842f55dec6133260ea8f53c4257d64494c534f306bf7a9", size = 64769, upload-time = "2025-10-08T09:14:47.334Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/3e/b4547e3a34210956382eed1c85935fff7e0f9b98be3106b3745d7dec9c5e/msgpack-1.1.2-cp310-cp310-win_amd64.whl", hash = "sha256:db6192777d943bdaaafb6ba66d44bf65aa0e9c5616fa1d2da9bb08828c6b39aa", size = 71293, upload-time = "2025-10-08T09:14:48.665Z" },
 ]
 
 [[package]]
@@ -1244,7 +1315,7 @@ name = "mypy"
 version = "1.20.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "librt", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "librt", marker = "platform_python_implementation != 'PyPy' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
     { name = "mypy-extensions" },
     { name = "pathspec" },
     { name = "tomli" },
@@ -1355,12 +1426,33 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas"
+version = "13.1.0.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/a5/fce49e2ae977e0ccc084e5adafceb4f0ac0c8333cb6863501618a7277f67/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:c86fc7f7ae36d7528288c5d88098edcb7b02c633d262e7ddbb86b0ad91be5df2", size = 542851226, upload-time = "2025-10-09T08:59:04.818Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/44/423ac00af4dd95a5aeb27207e2c0d9b7118702149bf4704c3ddb55bb7429/nvidia_cublas-13.1.0.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:ee8722c1f0145ab246bccb9e452153b5e0515fd094c3678df50b2a0888b8b171", size = 423133236, upload-time = "2025-10-09T08:59:32.536Z" },
+    { url = "https://files.pythonhosted.org/packages/10/f5/f50bc3f5c2bb57ab8f5b4d78bc1146b57810d42cb8fcb28cbe2e14050376/nvidia_cublas-13.1.0.3-py3-none-win_amd64.whl", hash = "sha256:2a3b94a37def342471c59fad7856caee4926809a72dd5270155d6a31b5b277be", size = 404355960, upload-time = "2025-10-09T09:07:00.987Z" },
+]
+
+[[package]]
 name = "nvidia-cublas-cu12"
 version = "12.8.3.14"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ed/63/684a6f72f52671ea222c12ecde9bdf748a0ba025e2ad3ec374e466c26eb6/nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:93a4e0e386cc7f6e56c822531396de8170ed17068a1e18f987574895044cd8c3", size = 604900717, upload-time = "2025-01-23T17:52:55.486Z" },
     { url = "https://files.pythonhosted.org/packages/82/df/4b01f10069e23c641f116c62fc31e31e8dc361a153175d81561d15c8143b/nvidia_cublas_cu12-12.8.3.14-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:3f0e05e7293598cf61933258b73e66a160c27d59c4422670bf0b79348c04be44", size = 609620630, upload-time = "2025-01-23T17:55:00.753Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/54/fbfa3315b936d3358517f7da5f9f2557c279bf210e5261f0cf66cc0f9832/nvidia_cublas_cu12-12.8.3.14-py3-none-win_amd64.whl", hash = "sha256:9ae5eae500aead01fc4bdfc458209df638b1a3551557ce11a78eea9ece602ae9", size = 578387959, upload-time = "2025-01-23T18:08:00.662Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/df/b74b10025c1205695c5676373f2edd3e87a7202cc62ead0dfbc373b0f6ea/nvidia_cuda_cupti-13.0.85-py3-none-win_amd64.whl", hash = "sha256:683f58d301548deeefcb8f6fac1b8d907691b9d8b18eccab417f51e362102f00", size = 7736776, upload-time = "2025-09-04T08:38:08.38Z" },
 ]
 
 [[package]]
@@ -1370,6 +1462,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/53/458956a65283c55c22ba40a65745bbe9ff20c10b68ea241bc575e20c0465/nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ff154211724fd824e758ce176b66007b558eea19c9a5135fc991827ee147e317", size = 9526469, upload-time = "2025-01-23T17:47:33.104Z" },
     { url = "https://files.pythonhosted.org/packages/39/6f/3683ecf4e38931971946777d231c2df00dd5c1c4c2c914c42ad8f9f4dca6/nvidia_cuda_cupti_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e0b2eb847de260739bee4a3f66fac31378f4ff49538ff527a38a01a9a39f950", size = 10237547, upload-time = "2025-01-23T17:47:56.863Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/2a/cabe033045427beb042b70b394ac3fd7cfefe157c965268824011b16af67/nvidia_cuda_cupti_cu12-12.8.57-py3-none-win_amd64.whl", hash = "sha256:bbed719c52a476958a74cfc42f2b95a3fd6b3fd94eb40134acc4601feb4acac3", size = 7002337, upload-time = "2025-01-23T18:04:35.34Z" },
 ]
 
 [[package]]
@@ -1379,6 +1472,17 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/48/b54a06168a2190572a312bfe4ce443687773eb61367ced31e064953dd2f7/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:5d6a0d32fdc7ea39917c20065614ae93add6f577d840233237ff08e9a38f58f0", size = 40546229, upload-time = "2025-06-05T20:01:53.357Z" },
     { url = "https://files.pythonhosted.org/packages/d6/5c/8cc072436787104bbbcbde1f76ab4a0d89e68f7cebc758dd2ad7913a43d0/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:44e1eca4d08926193a558d2434b1bf83d57b4d5743e0c431c0c83d51da1df62b", size = 39411138, upload-time = "2025-06-05T20:01:43.182Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/9e/c71c53655a65d7531c89421c282359e2f626838762f1ce6180ea0bbebd29/nvidia_cuda_nvcc_cu12-12.9.86-py3-none-win_amd64.whl", hash = "sha256:8ed7f0b17dea662755395be029376db3b94fed5cbb17c2d35cc866c5b1b84099", size = 34669845, upload-time = "2025-06-05T20:11:56.308Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/af/345fedb9f4c76c84ab4fa445b36bd4048a4d9db60e6bc76b4f913ff4b852/nvidia_cuda_nvrtc-13.0.88-py3-none-win_amd64.whl", hash = "sha256:6bcd4e7f8e205cbe644f5a98f2f799bef9556fefc89dd786e79a16312ce49872", size = 76807835, upload-time = "2025-09-04T08:39:15.274Z" },
 ]
 
 [[package]]
@@ -1387,6 +1491,18 @@ version = "12.8.61"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/22/32029d4583f7b19cfe75c84399cbcfd23f2aaf41c66fc8db4da460104fff/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a0fa9c2a21583105550ebd871bd76e2037205d56f33f128e69f6d2a55e0af9ed", size = 88024585, upload-time = "2025-01-23T17:50:10.722Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/98/29f98d57fc40d6646337e942d37509c6d5f8abe29012671f7a6eb9978ebe/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b1f376bf58111ca73dde4fd4df89a462b164602e074a76a2c29c121ca478dcd4", size = 43097015, upload-time = "2025-01-23T17:49:44.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5b/052d05aa068e4752415ad03bac58e852ea8bc17c9321e08546b3f261e47e/nvidia_cuda_nvrtc_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:9c8887bf5e5dffc441018ba8c5dc59952372a6f4806819e8c1f03d62637dbeea", size = 73567440, upload-time = "2025-01-23T18:05:51.036Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/94/6b867483bec07da24ffa32736c79fabb94ef3a7af4d787a9d4a974868576/nvidia_cuda_runtime-13.0.96-py3-none-win_amd64.whl", hash = "sha256:f79298c8a098cec150a597c8eba58ecdab96e3bdc4b9bc4f9983635031740492", size = 2927037, upload-time = "2025-10-09T09:04:23.782Z" },
 ]
 
 [[package]]
@@ -1396,6 +1512,7 @@ source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cd/9d/e77ec4227e70c6006195bdf410370f2d0e5abfa2dc0d1d315cacd57c5c88/nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:534ccebd967b6a44292678fa5da4f00666029cb2ed07a79515ea41ef31fe3ec7", size = 965264, upload-time = "2025-01-23T17:47:11.759Z" },
     { url = "https://files.pythonhosted.org/packages/16/f6/0e1ef31f4753a44084310ba1a7f0abaf977ccd810a604035abb43421c057/nvidia_cuda_runtime_cu12-12.8.57-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:75342e28567340b7428ce79a5d6bb6ca5ff9d07b69e7ce00d2c7b4dc23eff0be", size = 954762, upload-time = "2025-01-23T17:47:22.21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ee/52508c74bee2a3de8d59c6fd9af4ca2f216052fa2bc916da3a6a7bb998af/nvidia_cuda_runtime_cu12-12.8.57-py3-none-win_amd64.whl", hash = "sha256:89be637e3ee967323865b85e0f147d75f9a5bd98360befa37481b02dd57af8f5", size = 944309, upload-time = "2025-01-23T18:04:23.143Z" },
 ]
 
 [[package]]
@@ -1403,11 +1520,38 @@ name = "nvidia-cudnn-cu12"
 version = "9.7.1.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/2e/ec5dda717eeb1de3afbbbb611ca556f9d6d057470759c6abd36d72f0063b/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:848a61d40ef3b32bd4e1fadb599f0cf04a4b942fbe5fb3be572ad75f9b8c53ef", size = 725862213, upload-time = "2025-02-06T22:14:57.169Z" },
     { url = "https://files.pythonhosted.org/packages/25/dc/dc825c4b1c83b538e207e34f48f86063c88deaa35d46c651c7c181364ba2/nvidia_cudnn_cu12-9.7.1.26-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:6d011159a158f3cfc47bf851aea79e31bcff60d530b70ef70474c84cac484d07", size = 726851421, upload-time = "2025-02-06T22:18:29.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/ea/636cda41b3865caa0d43c34f558167304acde3d2c5f6c54c00a550e69ecd/nvidia_cudnn_cu12-9.7.1.26-py3-none-win_amd64.whl", hash = "sha256:7b805b9a4cf9f3da7c5f4ea4a9dff7baf62d1a612d6154a7e0d2ea51ed296241", size = 715962100, upload-time = "2025-02-06T22:21:32.431Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.19.0.56"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
+    { url = "https://files.pythonhosted.org/packages/91/a2/f020386683ee9ab2c9a9f7f79290d9b0d07f7241de54dc746af2abd188d2/nvidia_cudnn_cu13-9.19.0.56-py3-none-win_amd64.whl", hash = "sha256:40d8c375005bcb01495f8edf375230b203a411a0c05fb6dc92a3781edcb23eac", size = 350547366, upload-time = "2026-02-03T20:50:49.563Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.0.0.61"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b2/f8af21a2ed1beed337a6a02c5a28aeb85441f4d578ec3d529543c775ea4b/nvidia_cufft-12.0.0.61-py3-none-win_amd64.whl", hash = "sha256:2abce5b39d2f5ae12730fb7e5db6696533e36c26e2d3e8fd1750bdd2853364eb", size = 213342123, upload-time = "2025-09-04T08:40:51.145Z" },
 ]
 
 [[package]]
@@ -1415,11 +1559,21 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.41"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/72/95/6157cb45a49f5090a470de42353a22a0ed5b13077886dca891b4b0e350fe/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68509dcd7e3306e69d0e2d8a6d21c8b25ed62e6df8aac192ce752f17677398b5", size = 193108626, upload-time = "2025-01-23T17:55:49.192Z" },
     { url = "https://files.pythonhosted.org/packages/ac/26/b53c493c38dccb1f1a42e1a21dc12cba2a77fbe36c652f7726d9ec4aba28/nvidia_cufft_cu12-11.3.3.41-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:da650080ab79fcdf7a4b06aa1b460e99860646b176a43f6208099bdc17836b6a", size = 193118795, upload-time = "2025-01-23T17:56:30.536Z" },
+    { url = "https://files.pythonhosted.org/packages/32/f3/f6248aa119c2726b1bdd02d472332cae274133bd32ca5fa8822efb0c308c/nvidia_cufft_cu12-11.3.3.41-py3-none-win_amd64.whl", hash = "sha256:f9760612886786601d27a0993bb29ce1f757e6b8b173499d0ecfa850d31b50f8", size = 192216738, upload-time = "2025-01-23T18:08:51.102Z" },
+]
+
+[[package]]
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
 ]
 
 [[package]]
@@ -1428,6 +1582,17 @@ version = "1.13.0.11"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/9c/1f3264d0a84c8a031487fb7f59780fc78fa6f1c97776233956780e3dc3ac/nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:483f434c541806936b98366f6d33caef5440572de8ddf38d453213729da3e7d4", size = 1197801, upload-time = "2025-01-23T17:57:07.247Z" },
+    { url = "https://files.pythonhosted.org/packages/35/80/f6a0fc90ab6fa4ac916f3643e5b620fd19724626c59ae83b74f5efef0349/nvidia_cufile_cu12-1.13.0.11-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:2acbee65dc2eaf58331f0798c5e6bcdd790c4acb26347530297e63528c9eba5d", size = 1120660, upload-time = "2025-01-23T17:56:56.608Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+    { url = "https://files.pythonhosted.org/packages/99/27/72103153b1ffc00e09fdc40ac970235343dcd1ea8bd762e84d2d73219ffa/nvidia_curand-10.4.0.35-py3-none-win_amd64.whl", hash = "sha256:65b1710aa6961d326b411e314b374290904c5ddf41dc3f766ebc3f1d7d4ca69f", size = 55242481, upload-time = "2025-08-04T10:30:41.831Z" },
 ]
 
 [[package]]
@@ -1435,7 +1600,24 @@ name = "nvidia-curand-cu12"
 version = "10.3.9.55"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/13/bbcf48e2f8a6a9adef58f130bc968810528a4e66bbbe62fad335241e699f/nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b6bb90c044fa9b07cedae2ef29077c4cf851fb6fdd6d862102321f359dca81e9", size = 63623836, upload-time = "2025-01-23T17:57:22.319Z" },
     { url = "https://files.pythonhosted.org/packages/bd/fc/7be5d0082507269bb04ac07cc614c84b78749efb96e8cf4100a8a1178e98/nvidia_curand_cu12-10.3.9.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8387d974240c91f6a60b761b83d4b2f9b938b7e0b9617bae0f0dafe4f5c36b86", size = 63618038, upload-time = "2025-01-23T17:57:41.838Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f0/91252f3cffe3f3c233a8e17262c21b41534652edfe783c1e58ea1c92c115/nvidia_curand_cu12-10.3.9.55-py3-none-win_amd64.whl", hash = "sha256:570d82475fe7f3d8ed01ffbe3b71796301e0e24c98762ca018ff8ce4f5418e1f", size = 62761446, upload-time = "2025-01-23T18:09:21.663Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/332a0101260ca78a1daef046bf0b06199e8ed4dac1d2aa698289c358169c/nvidia_cusolver-12.0.4.66-py3-none-win_amd64.whl", hash = "sha256:16515bd33a8e76bb54d024cfa068fa68d30e80fc34b9e1090813ea9362e0cb65", size = 193551444, upload-time = "2025-09-04T08:41:46.813Z" },
 ]
 
 [[package]]
@@ -1443,13 +1625,27 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.2.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8c/ce/4214a892e804b20bf66d04f04a473006fc2d3dac158160ef85f1bc906639/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:0fd9e98246f43c15bee5561147ad235dfdf2d037f5d07c9d41af3f7f72feb7cc", size = 260094827, upload-time = "2025-01-23T17:58:17.586Z" },
     { url = "https://files.pythonhosted.org/packages/c2/08/953675873a136d96bb12f93b49ba045d1107bc94d2551c52b12fa6c7dec3/nvidia_cusolver_cu12-11.7.2.55-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4d1354102f1e922cee9db51920dba9e2559877cf6ff5ad03a00d853adafb191b", size = 260373342, upload-time = "2025-01-23T17:58:56.406Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f9/e0e6f8b7aecd13e0f9e937d116fb3211329a0a92b9bea9624b1368de307a/nvidia_cusolver_cu12-11.7.2.55-py3-none-win_amd64.whl", hash = "sha256:a5a516c55da5c5aba98420d9bc9bcab18245f21ec87338cc1f930eb18dd411ac", size = 249600787, upload-time = "2025-01-23T18:10:07.641Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.6.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
+    { url = "https://files.pythonhosted.org/packages/02/b0/b043d6f3480f102f885cf87fc3ffd3edcb5e23b855025a50e2ef4d059185/nvidia_cusparse-12.6.3.3-py3-none-win_amd64.whl", hash = "sha256:cbcf42feb737bd7ec15b4c0a63e62351886bd3f975027b8815d7f720a2b5ea79", size = 143783033, upload-time = "2025-09-04T08:42:12.391Z" },
 ]
 
 [[package]]
@@ -1457,11 +1653,12 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.7.53"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2e/a2/313db0453087f5324a5900380ca2e57e050c8de76f407b5e11383dc762ae/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d869c6146ca80f4305b62e02d924b4aaced936f8173e3cef536a67eed2a91af1", size = 291963692, upload-time = "2025-01-23T17:59:40.325Z" },
     { url = "https://files.pythonhosted.org/packages/c2/ab/31e8149c66213b846c082a3b41b1365b831f41191f9f40c6ddbc8a7d550e/nvidia_cusparse_cu12-12.5.7.53-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3c1b61eb8c85257ea07e9354606b26397612627fdcd327bfd91ccf6155e7c86d", size = 292064180, upload-time = "2025-01-23T18:00:23.233Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/48/64b01653919a3d1d9b5117c156806ab0db8312c7496ff646477a5c1545bf/nvidia_cusparse_cu12-12.5.7.53-py3-none-win_amd64.whl", hash = "sha256:82c201d6781bacf6bb7c654f0446728d0fe596dfdd82ef4a04c204ce3e107441", size = 288767123, upload-time = "2025-01-23T18:11:01.543Z" },
 ]
 
 [[package]]
@@ -1469,7 +1666,19 @@ name = "nvidia-cusparselt-cu12"
 version = "0.6.3"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/62/da/4de092c61c6dea1fc9c936e69308a02531d122e12f1f649825934ad651b5/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8371549623ba601a06322af2133c4a44350575f5a3108fb75f3ef20b822ad5f1", size = 156402859, upload-time = "2024-10-16T02:23:17.184Z" },
     { url = "https://files.pythonhosted.org/packages/3b/9a/72ef35b399b0e183bc2e8f6f558036922d453c4d8237dab26c666a04244b/nvidia_cusparselt_cu12-0.6.3-py3-none-manylinux2014_x86_64.whl", hash = "sha256:e5c8a26c36445dd2e6812f1177978a24e2d37cacce7e090f297a688d1ec44f46", size = 156785796, upload-time = "2024-10-15T21:29:17.709Z" },
+    { url = "https://files.pythonhosted.org/packages/46/3e/9e1e394a02a06f694be2c97bbe47288bb7c90ea84c7e9cf88f7b28afe165/nvidia_cusparselt_cu12-0.6.3-py3-none-win_amd64.whl", hash = "sha256:3b325bcbd9b754ba43df5a311488fca11a6b5dc3d11df4d190c000cf1a0765c7", size = 155595972, upload-time = "2024-10-15T22:58:35.426Z" },
+]
+
+[[package]]
+name = "nvidia-cusparselt-cu13"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/10/8dcd1175260706a2fc92a16a52e306b71d4c1ea0b0cc4a9484183399818a/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:400c6ed1cf6780fc6efedd64ec9f1345871767e6a1a0a552a1ea0578117ea77c", size = 220791277, upload-time = "2025-08-13T19:22:40.982Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/53/43b0d71f4e702fa9733f8b4571fdca50a8813f1e450b656c239beff12315/nvidia_cusparselt_cu13-0.8.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:25e30a8a7323935d4ad0340b95a0b69926eee755767e8e0b1cf8dd85b197d3fd", size = 169884119, upload-time = "2025-08-13T19:23:41.967Z" },
+    { url = "https://files.pythonhosted.org/packages/57/de/8f0578928b9b1246d7b1324db0528e6b9f9fb54496a49f40bf71f09f1a27/nvidia_cusparselt_cu13-0.8.0-py3-none-win_amd64.whl", hash = "sha256:e80212ed7b1afc97102fbb2b5c82487aa73f6a0edfa6d26c5a152593e520bb8f", size = 156459710, upload-time = "2025-08-13T19:24:18.043Z" },
 ]
 
 [[package]]
@@ -1491,12 +1700,51 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-nccl-cu13"
+version = "2.28.9"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/55/1920646a2e43ffd4fc958536b276197ed740e9e0c54105b4bb3521591fc7/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:01c873ba1626b54caa12272ed228dc5b2781545e0ae8ba3f432a8ef1c6d78643", size = 196561677, upload-time = "2025-11-18T05:49:03.45Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b4/878fefaad5b2bcc6fcf8d474a25e3e3774bc5133e4b58adff4d0bca238bc/nvidia_nccl_cu13-2.28.9-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:e4553a30f34195f3fa1da02a6da3d6337d28f2003943aa0a3d247bbc25fefc42", size = 196493177, upload-time = "2025-11-18T05:49:17.677Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/7a/123e033aaff487c77107195fa5a2b8686795ca537935a24efae476c41f05/nvidia_nvjitlink-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:13a74f429e23b921c1109976abefacc69835f2f433ebd323d3946e11d804e47b", size = 40713933, upload-time = "2025-09-04T08:35:43.553Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2c/93c5250e64df4f894f1cbb397c6fd71f79813f9fd79d7cd61de3f97b3c2d/nvidia_nvjitlink-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e931536ccc7d467a98ba1d8b89ff7fa7f1fa3b13f2b0069118cd7f47bff07d0c", size = 38768748, upload-time = "2025-09-04T08:35:20.008Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/01/07530b0e37546231052e30234540289c42eaffa486f1a34a87fed340157b/nvidia_nvjitlink-13.0.88-py3-none-win_amd64.whl", hash = "sha256:634e96e3da9ef845ae744097a1f289238ecf946ce0b82e93cdce14b9782e682f", size = 36035115, upload-time = "2025-09-04T08:43:03.001Z" },
+]
+
+[[package]]
 name = "nvidia-nvjitlink-cu12"
 version = "12.8.61"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/f8/9d85593582bd99b8d7c65634d2304780aefade049b2b94d96e44084be90b/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:45fd79f2ae20bd67e8bc411055939049873bfd8fac70ff13bd4865e0b9bdab17", size = 39243473, upload-time = "2025-01-23T18:03:03.509Z" },
     { url = "https://files.pythonhosted.org/packages/af/53/698f3758f48c5fcb1112721e40cc6714da3980d3c7e93bae5b29dafa9857/nvidia_nvjitlink_cu12-12.8.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:9b80ecab31085dda3ce3b41d043be0ec739216c3fc633b8abe212d5a30026df0", size = 38374634, upload-time = "2025-01-23T18:02:35.812Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c6/0d1b2bfeb2ef42c06db0570c4d081e5cde4450b54c09e43165126cfe6ff6/nvidia_nvjitlink_cu12-12.8.61-py3-none-win_amd64.whl", hash = "sha256:1166a964d25fdc0eae497574d38824305195a5283324a21ccb0ce0c802cbf41c", size = 268514099, upload-time = "2025-01-23T18:12:33.874Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/50/0e2220f8620a177de994211186ffc5bfa9f2ce1e1282797f8f90096f9f88/nvidia_nvtx-13.0.85-py3-none-win_amd64.whl", hash = "sha256:d66ea44254dd3c6eacc300047af6e1288d2269dd072b417e0adffbf479e18519", size = 137066, upload-time = "2025-09-04T08:39:25.649Z" },
 ]
 
 [[package]]
@@ -1504,7 +1752,9 @@ name = "nvidia-nvtx-cu12"
 version = "12.8.55"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/bb/e8/ae6ecbdade8bb9174d75db2b302c57c1c27d9277d6531c62aafde5fb32a3/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c38405335fbc0f0bf363eaeaeb476e8dfa8bae82fada41d25ace458b9ba9f3db", size = 91103, upload-time = "2025-01-23T17:50:24.664Z" },
     { url = "https://files.pythonhosted.org/packages/8d/cd/0e8c51b2ae3a58f054f2e7fe91b82d201abfb30167f2431e9bd92d532f42/nvidia_nvtx_cu12-12.8.55-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2dd0780f1a55c21d8e06a743de5bd95653de630decfff40621dbde78cc307102", size = 89896, upload-time = "2025-01-23T17:50:44.487Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/14/84d46e62bfde46dd20cfb041e0bb5c2ec454fd6a384696e7fa3463c5bb59/nvidia_nvtx_cu12-12.8.55-py3-none-win_amd64.whl", hash = "sha256:9022681677aef1313458f88353ad9c0d2fbbe6402d6b07c9f00ba0e3ca8774d3", size = 56435, upload-time = "2025-01-23T18:06:06.268Z" },
 ]
 
 [[package]]
@@ -1630,11 +1880,11 @@ name = "optax"
 version = "0.2.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "sys_platform == 'linux'" },
-    { name = "chex", marker = "sys_platform == 'linux'" },
-    { name = "jax", marker = "sys_platform == 'linux'" },
-    { name = "jaxlib", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "absl-py", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "chex", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jax", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jaxlib", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c0/75/1e011953c48be502d4d84fa8458e91be7c6f983002511669bddd7b1a065f/optax-0.2.5.tar.gz", hash = "sha256:b2e38c7aea376186deae758ba7a258e6ef760c6f6131e9e11bc561c65386d594", size = 258548, upload-time = "2025-06-10T17:00:47.544Z" }
 wheels = [
@@ -1646,16 +1896,20 @@ name = "optree"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/83/8e/09d899ad531d50b79aa24e7558f604980fe4048350172e643bb1b9983aec/optree-0.18.0.tar.gz", hash = "sha256:3804fb6ddc923855db2dc4805b4524c66e00f1ef30b166be4aadd52822b13e06", size = 165178, upload-time = "2025-11-14T08:58:31.234Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/45/22dfc0a3a8ca568c2702d725cdce85e2e1767d4241f2ac7d28c518ce7019/optree-0.18.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1f19867b02a547fc9f11d27c0413e7483cef89699e16f3b9e8af73a9b25e6061", size = 353272, upload-time = "2025-11-14T08:56:31.887Z" },
+    { url = "https://files.pythonhosted.org/packages/73/ba/f89cd7fe3fca9f434b6cd6ba80716f1ad59f40453482c04d6887e5c516de/optree-0.18.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ad428ccdb2a40804919880dfe8d2a3021fd4418be15ea7ecb8434ab249badf9f", size = 330497, upload-time = "2025-11-14T08:56:33.447Z" },
     { url = "https://files.pythonhosted.org/packages/73/93/463a531b863bffae92d6d1c7857f655234f12ad46fe088bf5bd5cd37cd67/optree-0.18.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e058cc51d9d57b45801060af9f74765b95bedfc59fd6df1c7489ae0825126be5", size = 349724, upload-time = "2025-11-14T08:56:34.475Z" },
     { url = "https://files.pythonhosted.org/packages/b9/4f/7d54f0eeea24f5893422d65fce835d80e644ebac8a4570d762f994cfe97c/optree-0.18.0-cp310-cp310-manylinux_2_26_i686.manylinux_2_28_i686.whl", hash = "sha256:daab231cf768937ce4675376ea3e214d399116d9867a6737372c31c58630bdfc", size = 404190, upload-time = "2025-11-14T08:56:35.622Z" },
     { url = "https://files.pythonhosted.org/packages/66/af/044080368dc8ab809c5b089ad3132e7775043c5a8a165465df1f0c99dd62/optree-0.18.0-cp310-cp310-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ea357657143f364a764b63b2b1ce12d77156d48a1f32def990b696d755acb629", size = 401798, upload-time = "2025-11-14T08:56:37.001Z" },
     { url = "https://files.pythonhosted.org/packages/0b/97/c449712ccb50af3cb2608718e503e31b259aa55de40ee83bebb159b07593/optree-0.18.0-cp310-cp310-manylinux_2_26_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f81f5340c8df50662abaf753ab07095901e40b934efb27da50032a4ae71c5a97", size = 397477, upload-time = "2025-11-14T08:56:38.298Z" },
     { url = "https://files.pythonhosted.org/packages/66/8e/bdda357f31e2b7c80b61b9785e6dea25e94c01e7237c7a8b1af38f369ee4/optree-0.18.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:66f142c743732cd4e630ea84415f654a00c792793c7f80d4511167f0f89796a6", size = 386631, upload-time = "2025-11-14T08:56:39.707Z" },
     { url = "https://files.pythonhosted.org/packages/a8/2f/32575d5ac11993c19a6b60f6e15cafcc807adabf92caf06824bc3b5d50f9/optree-0.18.0-cp310-cp310-manylinux_2_39_riscv64.whl", hash = "sha256:55a2ccd121fccc9df961e982db2f4e8f2b4f7015e814ef70b1140514cdffe214", size = 347972, upload-time = "2025-11-14T08:56:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/7d/72bc9147ed59a6a1cab4e0c43a27d6542029a66c46c5301d05f990dd1991/optree-0.18.0-cp310-cp310-win32.whl", hash = "sha256:090a3f0ccafa0fe99d71e7d974ae52ff966ac26c409ec41f96556b96646054ef", size = 277698, upload-time = "2025-11-14T08:56:41.801Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/53/cf4e66ac4f134c2211a6f3f04e9d3a98effb6229316bcdadc3d3a9247362/optree-0.18.0-cp310-cp310-win_amd64.whl", hash = "sha256:0e0dbe995241efe70cfb522e89c1a7c968216926725a0e5e20cc72bd5d0311b1", size = 302673, upload-time = "2025-11-14T08:56:43.132Z" },
 ]
 
 [[package]]
@@ -1663,18 +1917,18 @@ name = "orbax-checkpoint"
 version = "0.11.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "sys_platform == 'linux'" },
-    { name = "etils", extra = ["epath", "epy"], marker = "sys_platform == 'linux'" },
-    { name = "humanize", marker = "sys_platform == 'linux'" },
-    { name = "jax", marker = "sys_platform == 'linux'" },
-    { name = "msgpack", marker = "sys_platform == 'linux'" },
-    { name = "nest-asyncio", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
-    { name = "pyyaml", marker = "sys_platform == 'linux'" },
-    { name = "simplejson", marker = "sys_platform == 'linux'" },
-    { name = "tensorstore", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
+    { name = "absl-py", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "etils", extra = ["epath", "epy"], marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "humanize", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jax", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "msgpack", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nest-asyncio", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "protobuf", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "pyyaml", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "simplejson", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "tensorstore", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/b4/262439a3fe00064b53a5182c0149447304f5a2d5a328a92d64390c18d189/orbax_checkpoint-0.11.5.tar.gz", hash = "sha256:8331ff594980a241ba43eb59dd683e5b590b339cff32a7b72d78cb5a350030b4", size = 249258, upload-time = "2025-02-11T19:33:45.364Z" }
 wheels = [
@@ -1813,7 +2067,7 @@ name = "pytest"
 version = "8.3.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
     { name = "exceptiongroup" },
     { name = "iniconfig" },
     { name = "packaging" },
@@ -1905,7 +2159,7 @@ version = "1.9.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
     { name = "rich" },
     { name = "typing-extensions" },
 ]
@@ -1924,11 +2178,13 @@ dependencies = [
     { name = "onnx" },
     { name = "onnxscript" },
     { name = "tensordict" },
-    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "torchvision", version = "0.22.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torchvision", version = "0.22.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torchvision", version = "0.22.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torchvision", version = "0.22.0", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'aarch64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_python_implementation != 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torchvision", version = "0.22.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torchvision", version = "0.26.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "extra == 'extra-10-motrix-lab-rocm' or extra != 'extra-10-motrix-lab-cuda'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/aa/5b/5bea7c110c389f9336ebe5ad7cd9abbcbbb64d7de0d0f50c2af8fa2ce321/rsl_rl_lib-4.0.1.tar.gz", hash = "sha256:76a194e4834946716cc0e44dcd2be8b2254ac969c2452b145cd268c9cc908bf7", size = 41069, upload-time = "2026-02-09T09:15:10.927Z" }
 wheels = [
@@ -1940,14 +2196,19 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/2f/4966032c5f8cc7e6a60f1b2e0ad686293b9474b65246b0c642e3ef3badd0/scipy-1.15.3-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:a345928c86d535060c9c2b25e71e87c39ab2f22fc96e9636bd74d1dbf9de448c", size = 38702770, upload-time = "2025-05-08T16:04:20.849Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/6e/0c3bf90fae0e910c274db43304ebe25a6b391327f3f10b5dcc638c090795/scipy-1.15.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:ad3432cb0f9ed87477a8d97f03b763fd1d57709f1bbde3c9369b1dff5503b253", size = 30094511, upload-time = "2025-05-08T16:04:27.103Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b1/4deb37252311c1acff7f101f6453f0440794f51b6eacb1aad4459a134081/scipy-1.15.3-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:aef683a9ae6eb00728a542b796f52a5477b78252edede72b8327a886ab63293f", size = 22368151, upload-time = "2025-05-08T16:04:31.731Z" },
+    { url = "https://files.pythonhosted.org/packages/38/7d/f457626e3cd3c29b3a49ca115a304cebb8cc6f31b04678f03b216899d3c6/scipy-1.15.3-cp310-cp310-macosx_14_0_x86_64.whl", hash = "sha256:1c832e1bd78dea67d5c16f786681b28dd695a8cb1fb90af2e27580d3d0967e92", size = 25121732, upload-time = "2025-05-08T16:04:36.596Z" },
     { url = "https://files.pythonhosted.org/packages/db/0a/92b1de4a7adc7a15dcf5bddc6e191f6f29ee663b30511ce20467ef9b82e4/scipy-1.15.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:263961f658ce2165bbd7b99fa5135195c3a12d9bef045345016b8b50c315cb82", size = 35547617, upload-time = "2025-05-08T16:04:43.546Z" },
     { url = "https://files.pythonhosted.org/packages/8e/6d/41991e503e51fc1134502694c5fa7a1671501a17ffa12716a4a9151af3df/scipy-1.15.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9e2abc762b0811e09a0d3258abee2d98e0c703eee49464ce0069590846f31d40", size = 37662964, upload-time = "2025-05-08T16:04:49.431Z" },
     { url = "https://files.pythonhosted.org/packages/25/e1/3df8f83cb15f3500478c889be8fb18700813b95e9e087328230b98d547ff/scipy-1.15.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:ed7284b21a7a0c8f1b6e5977ac05396c0d008b89e05498c8b7e8f4a1423bba0e", size = 37238749, upload-time = "2025-05-08T16:04:55.215Z" },
     { url = "https://files.pythonhosted.org/packages/93/3e/b3257cf446f2a3533ed7809757039016b74cd6f38271de91682aa844cfc5/scipy-1.15.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:5380741e53df2c566f4d234b100a484b420af85deb39ea35a1cc1be84ff53a5c", size = 40022383, upload-time = "2025-05-08T16:05:01.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/55bc4881973d3f79b479a5a2e2df61c8c9a04fcb986a213ac9c02cfb659b/scipy-1.15.3-cp310-cp310-win_amd64.whl", hash = "sha256:9d61e97b186a57350f6d6fd72640f9e99d5a4a2b8fbf4b9ee9a841eab327dc13", size = 41259201, upload-time = "2025-05-08T16:05:08.166Z" },
 ]
 
 [[package]]
@@ -1965,6 +2226,9 @@ version = "3.20.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f4/a1ac5ed32f7ed9a088d62a59d410d4c204b3b3815722e2ccfb491fa8251b/simplejson-3.20.2.tar.gz", hash = "sha256:5fe7a6ce14d1c300d80d08695b7f7e633de6cd72c80644021874d985b3393649", size = 85784, upload-time = "2025-09-26T16:29:36.64Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/09/2bf3761de89ea2d91bdce6cf107dcd858892d0adc22c995684878826cc6b/simplejson-3.20.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6d7286dc11af60a2f76eafb0c2acde2d997e87890e37e24590bb513bec9f1bc5", size = 94039, upload-time = "2025-09-26T16:27:29.283Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/33/c3277db8931f0ae9e54b9292668863365672d90fb0f632f4cf9829cb7d68/simplejson-3.20.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c01379b4861c3b0aa40cba8d44f2b448f5743999aa68aaa5d3ef7049d4a28a2d", size = 75894, upload-time = "2025-09-26T16:27:30.378Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ea/ae47b04d03c7c8a7b7b1a8b39a6e27c3bd424e52f4988d70aca6293ff5e5/simplejson-3.20.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a16b029ca25645b3bc44e84a4f941efa51bf93c180b31bd704ce6349d1fc77c1", size = 76116, upload-time = "2025-09-26T16:27:31.42Z" },
     { url = "https://files.pythonhosted.org/packages/4b/42/6c9af551e5a8d0f171d6dce3d9d1260068927f7b80f1f09834e07887c8c4/simplejson-3.20.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3e22a5fb7b1437ffb057e02e1936a3bfb19084ae9d221ec5e9f4cf85f69946b6", size = 138827, upload-time = "2025-09-26T16:27:32.486Z" },
     { url = "https://files.pythonhosted.org/packages/2b/22/5e268bbcbe9f75577491e406ec0a5536f5b2fa91a3b52031fea51cd83e1d/simplejson-3.20.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8b6ff02fc7b8555c906c24735908854819b0d0dc85883d453e23ca4c0445d01", size = 146772, upload-time = "2025-09-26T16:27:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/71/b4/800f14728e2ad666f420dfdb57697ca128aeae7f991b35759c09356b829a/simplejson-3.20.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2bfc1c396ad972ba4431130b42307b2321dba14d988580c1ac421ec6a6b7cee3", size = 134497, upload-time = "2025-09-26T16:27:35.211Z" },
@@ -1973,6 +2237,8 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/aa/b0/94ad2cf32f477c449e1f63c863d8a513e2408d651c4e58fe4b6a7434e168/simplejson-3.20.2-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:5d6f5bacb8cdee64946b45f2680afa3f54cd38e62471ceda89f777693aeca4e4", size = 140468, upload-time = "2025-09-26T16:27:39.015Z" },
     { url = "https://files.pythonhosted.org/packages/e5/46/827731e4163be3f987cb8ee90f5d444161db8f540b5e735355faa098d9bc/simplejson-3.20.2-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:8db6841fb796ec5af632f677abf21c6425a1ebea0d9ac3ef1a340b8dc69f52b8", size = 148700, upload-time = "2025-09-26T16:27:40.171Z" },
     { url = "https://files.pythonhosted.org/packages/c7/28/c32121064b1ec2fb7b5d872d9a1abda62df064d35e0160eddfa907118343/simplejson-3.20.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:c0a341f7cc2aae82ee2b31f8a827fd2e51d09626f8b3accc441a6907c88aedb7", size = 141323, upload-time = "2025-09-26T16:27:41.324Z" },
+    { url = "https://files.pythonhosted.org/packages/46/b6/c897c54326fe86dd12d101981171a49361949f4728294f418c3b86a1af77/simplejson-3.20.2-cp310-cp310-win32.whl", hash = "sha256:27f9c01a6bc581d32ab026f515226864576da05ef322d7fc141cd8a15a95ce53", size = 74377, upload-time = "2025-09-26T16:27:42.533Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/87/a6e03d4d80cca99c1fee4e960f3440e2f21be9470e537970f960ca5547f1/simplejson-3.20.2-cp310-cp310-win_amd64.whl", hash = "sha256:c0a63ec98a4547ff366871bf832a7367ee43d047bcec0b07b66c794e2137b476", size = 76081, upload-time = "2025-09-26T16:27:43.945Z" },
     { url = "https://files.pythonhosted.org/packages/05/5b/83e1ff87eb60ca706972f7e02e15c0b33396e7bdbd080069a5d1b53cf0d8/simplejson-3.20.2-py3-none-any.whl", hash = "sha256:3b6bb7fb96efd673eac2e4235200bfffdc2353ad12c54117e1e4e2fc485ac017", size = 57309, upload-time = "2025-09-26T16:29:35.312Z" },
 ]
 
@@ -2034,7 +2300,7 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "alabaster" },
     { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
     { name = "docutils" },
     { name = "imagesize" },
     { name = "jinja2" },
@@ -2225,8 +2491,9 @@ dependencies = [
     { name = "orjson" },
     { name = "packaging" },
     { name = "pyvers" },
-    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/50/bc/2411956883bf1c7531e107dd79225ca47ce4a42d9306da015f625a6f08c5/tensordict-0.11.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:269a94f6afd8229718f8a657bf093f2c861dd24223625fdadfed446cf4cdf86e", size = 813584, upload-time = "2026-01-26T11:35:55.172Z" },
@@ -2240,31 +2507,33 @@ name = "tensorflow"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "absl-py", marker = "sys_platform == 'linux'" },
-    { name = "astunparse", marker = "sys_platform == 'linux'" },
-    { name = "flatbuffers", marker = "sys_platform == 'linux'" },
-    { name = "gast", marker = "sys_platform == 'linux'" },
-    { name = "google-pasta", marker = "sys_platform == 'linux'" },
-    { name = "grpcio", marker = "sys_platform == 'linux'" },
-    { name = "h5py", marker = "sys_platform == 'linux'" },
-    { name = "keras", marker = "sys_platform == 'linux'" },
-    { name = "libclang", marker = "sys_platform == 'linux'" },
-    { name = "ml-dtypes", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
-    { name = "opt-einsum", marker = "sys_platform == 'linux'" },
-    { name = "packaging", marker = "sys_platform == 'linux'" },
-    { name = "protobuf", marker = "sys_platform == 'linux'" },
-    { name = "requests", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", marker = "sys_platform == 'linux'" },
-    { name = "six", marker = "sys_platform == 'linux'" },
-    { name = "tensorboard", marker = "sys_platform == 'linux'" },
-    { name = "termcolor", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux'" },
-    { name = "wrapt", marker = "sys_platform == 'linux'" },
+    { name = "absl-py", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "astunparse", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "flatbuffers", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "gast", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "google-pasta", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "grpcio", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "h5py", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "keras", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "libclang", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "ml-dtypes", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "opt-einsum", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "packaging", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "protobuf", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "requests", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "setuptools", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "six", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "tensorboard", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "termcolor", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "wrapt", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/0e/9408083cb80d85024829eb78aa0aa799ca9f030a348acac35631b5191d4b/tensorflow-2.20.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e5f169f8f5130ab255bbe854c5f0ae152e93d3d1ac44f42cb1866003b81a5357", size = 200387116, upload-time = "2025-08-13T16:50:38.945Z" },
     { url = "https://files.pythonhosted.org/packages/ff/07/ea91ac67a9fd36d3372099f5a3e69860ded544f877f5f2117802388f4212/tensorflow-2.20.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02a0293d94f5c8b7125b66abf622cc4854a33ae9d618a0d41309f95e091bbaea", size = 259307122, upload-time = "2025-08-13T16:50:47.909Z" },
     { url = "https://files.pythonhosted.org/packages/e5/9e/0d57922cf46b9e91de636cd5b5e0d7a424ebe98f3245380a713f1f6c2a0b/tensorflow-2.20.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7abd7f3a010e0d354dc804182372779a722d474c4d8a3db8f4a3f5baef2a591e", size = 620425510, upload-time = "2025-08-13T16:51:02.608Z" },
+    { url = "https://files.pythonhosted.org/packages/74/b5/d40e1e389e07de9d113cf8e5d294c04d06124441d57606febfd0fb2cf5a6/tensorflow-2.20.0-cp310-cp310-win_amd64.whl", hash = "sha256:4a69ac2c2ce20720abf3abf917b4e86376326c0976fcec3df330e184b81e4088", size = 331664937, upload-time = "2025-08-13T16:51:17.719Z" },
 ]
 
 [[package]]
@@ -2272,13 +2541,16 @@ name = "tensorstore"
 version = "0.1.78"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ml-dtypes", marker = "sys_platform == 'linux'" },
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "ml-dtypes", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/9f/ee/05eb424437f4db63331c90e4605025eedc0f71da3faff97161d5d7b405af/tensorstore-0.1.78.tar.gz", hash = "sha256:e26074ffe462394cf54197eb76d6569b500f347573cd74da3f4dd5f510a4ad7c", size = 6913502, upload-time = "2025-10-06T17:44:29.649Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/1e/77eff7bb320f72a9cb6e9a19eee4d78bee4a6ac1c28ceef60df28b4ab670/tensorstore-0.1.78-cp310-cp310-macosx_10_14_x86_64.whl", hash = "sha256:f1bc58164ad964d9cc298d20b62ca704ab6241639a21015e47ce6ea5b5cae27f", size = 15710776, upload-time = "2025-10-06T17:43:47.469Z" },
+    { url = "https://files.pythonhosted.org/packages/55/df/f74f8004b246006ae03c90c28e32d71eb8a86a5b325d2d84dda327babdcc/tensorstore-0.1.78-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1910101ea85b6507958da28628ef53712c5311df19a795f449604f82bae6a24b", size = 13771121, upload-time = "2025-10-06T17:43:49.88Z" },
     { url = "https://files.pythonhosted.org/packages/be/b8/ab0d0b2afc53f47fbfd95c10d9ae21d393019aca45c8513657b8d7002f1f/tensorstore-0.1.78-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e92195db0c8c3ca749f24b1e930ab93382ac27430ac4ad2e3f53fc8f739323f", size = 18154513, upload-time = "2025-10-06T17:43:51.694Z" },
     { url = "https://files.pythonhosted.org/packages/f7/ea/c1b4cc6a089a39f63e8d189a55c715e393995628b12b4c8560b3ae4874ba/tensorstore-0.1.78-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90570b867f9100f7405e4116c73910d0bd283a101500ea5680c5a8a881ea05c6", size = 20048971, upload-time = "2025-10-06T17:43:54.358Z" },
+    { url = "https://files.pythonhosted.org/packages/58/2a/7167087885b12473f20ae4fddb9a8feeed6bd44ea8d42c73ae29ad3d1591/tensorstore-0.1.78-cp310-cp310-win_amd64.whl", hash = "sha256:4de9d4ee93d712cb665890af0738f4d74cac3b9b9a0492d477a3ee63fbbf445b", size = 12707793, upload-time = "2025-10-06T17:43:56.405Z" },
 ]
 
 [[package]]
@@ -2310,60 +2582,93 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "filelock", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "fsspec", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "jinja2", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "networkx", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "sympy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "typing-extensions", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/0b/b2b83f30b8e84a51bf4f96aa3f5f65fdf7c31c591cc519310942339977e2/torch-2.7.0-cp310-none-macosx_11_0_arm64.whl", hash = "sha256:34e0168ed6de99121612d72224e59b2a58a83dae64999990eada7260c5dd582d", size = 68559462, upload-time = "2025-04-23T14:35:39.889Z" },
-]
-
-[[package]]
-name = "torch"
 version = "2.7.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
+    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'",
     "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
-    "sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "fsspec", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "jinja2", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "networkx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "sympy", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
-    { name = "triton", marker = "sys_platform == 'linux'" },
-    { name = "typing-extensions", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "filelock", marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "fsspec", marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jinja2", marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "networkx", marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cublas-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cuda-cupti-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cuda-nvrtc-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cuda-runtime-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cudnn-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cufft-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cufile-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-curand-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusolver-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusparse-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusparselt-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nccl-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nvjitlink-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nvtx-cu12", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "sympy", marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "triton", version = "3.3.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "typing-extensions", marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:b1f0cdd0720ad60536deb5baa427b782fd920dd4fcf72e244d32974caafa3b9e", upload-time = "2025-05-14T03:33:41Z" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:ac1849553ee673dfafb44c610c60cb60a2890f0e117f43599a526cf777eb8b8c", upload-time = "2025-04-22T18:19:25Z" },
     { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.7.0%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:c52c4b869742f00b12cb34521d1381be6119fa46244791704b00cc4a3cb06850", upload-time = "2025-04-22T18:19:44Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')",
+    "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm'",
+    "sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm'",
+    "extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm'",
+]
+dependencies = [
+    { name = "cuda-bindings", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "filelock", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "fsspec", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "jinja2", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "networkx", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cudnn-cu13", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-cusparselt-cu13", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nccl-cu13", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "setuptools", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "sympy", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "typing-extensions", marker = "(platform_machine != 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and sys_platform != 'win32') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/f2/c1690994afe461aae2d0cac62251e6802a703dec0a6c549c02ecd0de92a9/torch-2.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:2c0d7fcfbc0c4e8bb5ebc3907cbc0c6a0da1b8f82b1fc6e14e914fa0b9baf74e", size = 80526521, upload-time = "2026-03-23T18:12:06.86Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/f0/98ae802fa8c09d3149b0c8690741f3f5753c90e779bd28c9613257295945/torch-2.11.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:4cf8687f4aec3900f748d553483ef40e0ac38411c3c48d0a86a438f6d7a99b18", size = 419723025, upload-time = "2026-03-23T18:11:43.774Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/1e/18a9b10b4bd34f12d4e561c52b0ae7158707b8193c6cfc0aad2b48167090/torch-2.11.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:1b32ceda909818a03b112006709b02be1877240c31750a8d9c6b7bf5f2d8a6e5", size = 530589207, upload-time = "2026-03-23T18:11:23.756Z" },
+    { url = "https://files.pythonhosted.org/packages/35/40/2d532e8c0e23705be9d1debce5bc37b68d59a39bda7584c26fe9668076fe/torch-2.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:b3c712ae6fb8e7a949051a953fc412fe0a6940337336c3b6f905e905dac5157f", size = 114518313, upload-time = "2026-03-23T18:11:58.281Z" },
+]
+
+[[package]]
+name = "torch"
+version = "2.11.0+rocm7.2"
+source = { registry = "https://download.pytorch.org/whl/rocm7.2" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux'",
+]
+dependencies = [
+    { name = "filelock", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "fsspec", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "jinja2", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "networkx", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "setuptools", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "sympy", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "triton-rocm", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "typing-extensions", marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/rocm7.2/torch-2.11.0%2Brocm7.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:0ead1a0e9bbc84484207cd905e9a424a6c7dcde94eb03d59c3da8972e4c964fe", upload-time = "2026-04-28T19:36:24Z" },
 ]
 
 [[package]]
@@ -2382,26 +2687,10 @@ wheels = [
 
 [[package]]
 name = "torchaudio"
-version = "2.7.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/26/abc66c79092ad2eaaade546dc93e23d99ddf2513988261b943d274f5c01a/torchaudio-2.7.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1c4a646c9e9347836c09e965eebc58dd028ec6ef34c46d3e7891bffd8dc645ea", size = 1842304, upload-time = "2025-04-23T14:47:09.135Z" },
-]
-
-[[package]]
-name = "torchaudio"
 version = "2.7.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
-    "sys_platform == 'win32'",
+    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'",
 ]
 dependencies = [
     { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
@@ -2419,9 +2708,9 @@ resolution-markers = [
     "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "pillow", marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
-    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'" },
+    { name = "numpy", marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'aarch64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_python_implementation != 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "pillow", marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'aarch64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_python_implementation != 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_machine != 'aarch64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_python_implementation != 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.22.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:566224d7b4f00bc6366bed1d62f834ca80f8e57fe41e10e4a5636bfa3ffb984e", upload-time = "2025-04-22T18:30:20Z" },
@@ -2429,33 +2718,15 @@ wheels = [
 
 [[package]]
 name = "torchvision"
-version = "0.22.0"
-source = { registry = "https://pypi.org/simple" }
-resolution-markers = [
-    "sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
-    "sys_platform == 'darwin'",
-]
-dependencies = [
-    { name = "numpy", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "pillow", marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-    { name = "torch", version = "2.7.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform != 'linux' and sys_platform != 'win32'" },
-]
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/eb/03/a514766f068b088180f273913e539d08e830be3ae46ef8577ea62584a27c/torchvision-0.22.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:72256f1d7ff510b16c9fb4dd488584d0693f40c792f286a9620674438a81ccca", size = 1947829, upload-time = "2025-04-23T14:42:04.652Z" },
-]
-
-[[package]]
-name = "torchvision"
 version = "0.22.0+cu128"
 source = { registry = "https://download.pytorch.org/whl/cu128" }
 resolution-markers = [
-    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux')",
-    "sys_platform == 'win32'",
+    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'",
 ]
 dependencies = [
-    { name = "numpy", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "pillow", marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
-    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "numpy", marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "pillow", marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.7.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "(platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'aarch64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (platform_python_implementation != 'CPython' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.22.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:59df5a550113a80ce523047066eaaedb168c69482da88c3ab246716ab45ba092", upload-time = "2025-04-22T18:30:20Z" },
@@ -2463,11 +2734,52 @@ wheels = [
 ]
 
 [[package]]
+name = "torchvision"
+version = "0.26.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "sys_platform != 'linux' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "pillow", marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(sys_platform != 'linux' and sys_platform != 'win32' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/b4/cdfee31e0402ea035135462cb0ab496e974d56fab6b4e7a1f0cbccb8cd28/torchvision-0.26.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a06d4772a8e13e772906ed736cc53ec6639e5e60554f8e5fa6ca165aabebc464", size = 1863503, upload-time = "2026-03-23T18:13:01.384Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/74/11fee109841e80ad14e5ca2d80bff6b10eb11b7838ff06f35bfeaa9f7251/torchvision-0.26.0-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2adfbe438473236191ff077a4a9a0c767436879c89628aa97137e959b0c11a94", size = 7766423, upload-time = "2026-03-23T18:12:56.049Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/00/24d8c7845c3f270153fb81395a5135b2778e2538e81d14c6aea5106c689c/torchvision-0.26.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b6f9ad1ecc0eab52647298b379ee9426845f8903703e6127973f8f3d049a798b", size = 7518249, upload-time = "2026-03-23T18:12:51.743Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ed/e53cd7c0da7ae002e5e929c1796ebbe7ec0c700c29f7a0a6696497fb3d8b/torchvision-0.26.0-cp310-cp310-win_amd64.whl", hash = "sha256:f13f12b3791a266de2d599cb8162925261622a037d87fc03132848343cf68f75", size = 3669784, upload-time = "2026-03-23T18:12:49.949Z" },
+]
+
+[[package]]
+name = "torchvision"
+version = "0.26.0+cu128"
+source = { registry = "https://download.pytorch.org/whl/cu128" }
+resolution-markers = [
+    "platform_machine == 'x86_64' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm'",
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')",
+    "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm'",
+    "extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm'",
+]
+dependencies = [
+    { name = "numpy", marker = "extra == 'extra-10-motrix-lab-rocm' or extra != 'extra-10-motrix-lab-cuda'" },
+    { name = "pillow", marker = "extra == 'extra-10-motrix-lab-rocm' or extra != 'extra-10-motrix-lab-cuda'" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "(platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm')" },
+    { name = "torch", version = "2.11.0+rocm7.2", source = { registry = "https://download.pytorch.org/whl/rocm7.2" }, marker = "(platform_machine == 'x86_64' and sys_platform == 'linux' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine != 'x86_64' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
+]
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:2a04bf491eb22e6487defe6cead6ffaabbce13fb5981b8eb3540050f96cb0599", upload-time = "2026-04-09T23:21:33Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:f44bfc61b9be80bcf52a762d34da363cea3125d10c01f37e271583803c7bb97b", upload-time = "2026-03-23T15:36:21Z" },
+    { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp310-cp310-win_amd64.whl", hash = "sha256:ed0770e00b96d8aa675718e20db69c740c927f027c9c8b1330251f8a973221b6", upload-time = "2026-04-09T23:21:33Z" },
+]
+
+[[package]]
 name = "tqdm"
 version = "4.67.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "colorama", marker = "sys_platform == 'win32' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
@@ -2479,7 +2791,7 @@ name = "treescope"
 version = "0.1.10"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'linux'" },
+    { name = "numpy", marker = "sys_platform == 'linux' or sys_platform == 'win32' or extra != 'extra-10-motrix-lab-cuda' or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f0/2a/d13d3c38862632742d2fe2f7ae307c431db06538fd05ca03020d207b5dcc/treescope-0.1.10.tar.gz", hash = "sha256:20f74656f34ab2d8716715013e8163a0da79bdc2554c16d5023172c50d27ea95", size = 138870, upload-time = "2025-08-08T05:43:48.048Z" }
 wheels = [
@@ -2490,11 +2802,37 @@ wheels = [
 name = "triton"
 version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(platform_machine != 'aarch64' and sys_platform == 'linux') or (platform_python_implementation != 'CPython' and sys_platform == 'linux') or sys_platform == 'win32'",
+    "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux'",
+]
 dependencies = [
-    { name = "setuptools", marker = "sys_platform == 'linux'" },
+    { name = "setuptools", marker = "(sys_platform == 'linux' and extra == 'extra-10-motrix-lab-cuda') or (sys_platform == 'win32' and extra == 'extra-10-motrix-lab-cuda') or (extra == 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/76/04/d54d3a6d077c646624dc9461b0059e23fd5d30e0dbe67471e3654aec81f9/triton-3.3.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fad99beafc860501d7fcc1fb7045d9496cbe2c882b1674640304949165a916e7", size = 156441993, upload-time = "2025-04-09T20:27:25.107Z" },
+]
+
+[[package]]
+name = "triton"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "(platform_machine != 'aarch64' and platform_machine != 'x86_64' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (platform_machine == 'aarch64' and platform_python_implementation != 'CPython' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm') or (sys_platform != 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm')",
+    "platform_machine == 'aarch64' and platform_python_implementation == 'CPython' and sys_platform == 'linux' and extra != 'extra-10-motrix-lab-cuda' and extra == 'extra-10-motrix-lab-rocm'",
+    "extra != 'extra-10-motrix-lab-cuda' and extra != 'extra-10-motrix-lab-rocm'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/ba/b1b04f4b291a3205d95ebd24465de0e5bf010a2df27a4e58a9b5f039d8f2/triton-3.6.0-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6c723cfb12f6842a0ae94ac307dba7e7a44741d720a40cf0e270ed4a4e3be781", size = 175972180, upload-time = "2026-01-20T16:15:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f7/f1c9d3424ab199ac53c2da567b859bcddbb9c9e7154805119f8bd95ec36f/triton-3.6.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a6550fae429e0667e397e5de64b332d1e5695b73650ee75a6146e2e902770bea", size = 188105201, upload-time = "2026-01-20T16:00:29.272Z" },
+]
+
+[[package]]
+name = "triton-rocm"
+version = "3.6.0"
+source = { registry = "https://download.pytorch.org/whl/rocm7.2" }
+wheels = [
+    { url = "https://download-r2.pytorch.org/whl/triton_rocm-3.6.0-cp310-cp310-linux_x86_64.whl", upload-time = "2026-01-20T18:39:31Z" },
 ]
 
 [[package]]
@@ -2552,12 +2890,18 @@ version = "2.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/49/2a/6de8a50cb435b7f42c46126cf1a54b2aab81784e74c8595c8e025e8f36d3/wrapt-2.0.1.tar.gz", hash = "sha256:9c9c635e78497cacb81e84f8b11b23e0aacac7a136e73b8e5b2109a1d9fc468f", size = 82040, upload-time = "2025-11-07T00:45:33.312Z" }
 wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/0d/12d8c803ed2ce4e5e7d5b9f5f602721f9dfef82c95959f3ce97fa584bb5c/wrapt-2.0.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:64b103acdaa53b7caf409e8d45d39a8442fe6dcfec6ba3f3d141e0cc2b5b4dbd", size = 77481, upload-time = "2025-11-07T00:43:11.103Z" },
+    { url = "https://files.pythonhosted.org/packages/05/3e/4364ebe221ebf2a44d9fc8695a19324692f7dd2795e64bd59090856ebf12/wrapt-2.0.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:91bcc576260a274b169c3098e9a3519fb01f2989f6d3d386ef9cbf8653de1374", size = 60692, upload-time = "2025-11-07T00:43:13.697Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/ff/ae2a210022b521f86a8ddcdd6058d137c051003812b0388a5e9a03d3fe10/wrapt-2.0.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ab594f346517010050126fcd822697b25a7031d815bb4fbc238ccbe568216489", size = 61574, upload-time = "2025-11-07T00:43:14.967Z" },
     { url = "https://files.pythonhosted.org/packages/c6/93/5cf92edd99617095592af919cb81d4bff61c5dbbb70d3c92099425a8ec34/wrapt-2.0.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:36982b26f190f4d737f04a492a68accbfc6fa042c3f42326fdfbb6c5b7a20a31", size = 113688, upload-time = "2025-11-07T00:43:18.275Z" },
     { url = "https://files.pythonhosted.org/packages/a0/0a/e38fc0cee1f146c9fb266d8ef96ca39fb14a9eef165383004019aa53f88a/wrapt-2.0.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:23097ed8bc4c93b7bf36fa2113c6c733c976316ce0ee2c816f64ca06102034ef", size = 115698, upload-time = "2025-11-07T00:43:19.407Z" },
     { url = "https://files.pythonhosted.org/packages/b0/85/bef44ea018b3925fb0bcbe9112715f665e4d5309bd945191da814c314fd1/wrapt-2.0.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8bacfe6e001749a3b64db47bcf0341da757c95959f592823a93931a422395013", size = 112096, upload-time = "2025-11-07T00:43:16.5Z" },
     { url = "https://files.pythonhosted.org/packages/7c/0b/733a2376e413117e497aa1a5b1b78e8f3a28c0e9537d26569f67d724c7c5/wrapt-2.0.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8ec3303e8a81932171f455f792f8df500fc1a09f20069e5c16bd7049ab4e8e38", size = 114878, upload-time = "2025-11-07T00:43:20.81Z" },
     { url = "https://files.pythonhosted.org/packages/da/03/d81dcb21bbf678fcda656495792b059f9d56677d119ca022169a12542bd0/wrapt-2.0.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:3f373a4ab5dbc528a94334f9fe444395b23c2f5332adab9ff4ea82f5a9e33bc1", size = 111298, upload-time = "2025-11-07T00:43:22.229Z" },
     { url = "https://files.pythonhosted.org/packages/c9/d5/5e623040e8056e1108b787020d56b9be93dbbf083bf2324d42cde80f3a19/wrapt-2.0.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:f49027b0b9503bf6c8cdc297ca55006b80c2f5dd36cecc72c6835ab6e10e8a25", size = 113361, upload-time = "2025-11-07T00:43:24.301Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/f3/de535ccecede6960e28c7b722e5744846258111d6c9f071aa7578ea37ad3/wrapt-2.0.1-cp310-cp310-win32.whl", hash = "sha256:8330b42d769965e96e01fa14034b28a2a7600fbf7e8f0cc90ebb36d492c993e4", size = 58035, upload-time = "2025-11-07T00:43:28.96Z" },
+    { url = "https://files.pythonhosted.org/packages/21/15/39d3ca5428a70032c2ec8b1f1c9d24c32e497e7ed81aed887a4998905fcc/wrapt-2.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:1218573502a8235bb8a7ecaed12736213b22dcde9feab115fa2989d42b5ded45", size = 60383, upload-time = "2025-11-07T00:43:25.804Z" },
+    { url = "https://files.pythonhosted.org/packages/43/c2/dfd23754b7f7a4dce07e08f4309c4e10a40046a83e9ae1800f2e6b18d7c1/wrapt-2.0.1-cp310-cp310-win_arm64.whl", hash = "sha256:eda8e4ecd662d48c28bb86be9e837c13e45c58b8300e43ba3c9b4fa9900302f7", size = 58894, upload-time = "2025-11-07T00:43:27.074Z" },
     { url = "https://files.pythonhosted.org/packages/15/d1/b51471c11592ff9c012bd3e2f7334a6ff2f42a7aed2caffcf0bdddc9cb89/wrapt-2.0.1-py3-none-any.whl", hash = "sha256:4d2ce1bf1a48c5277d7969259232b57645aae5686dba1eaeade39442277afbca", size = 44046, upload-time = "2025-11-07T00:45:32.116Z" },
 ]
 


### PR DESCRIPTION
Closes #24

## Summary

- Add mutually exclusive `cuda` / `rocm` extras in the root `pyproject.toml`: `cuda` pins torch 2.7.0 from the pytorch-cu128 index, `rocm` pins torch 2.11.0 + triton-rocm + amdsmi from the new pytorch-rocm72 index; declared conflicting under `[tool.uv]` so uv keeps both branches forked in a single `uv.lock`
- New `Makefile`: `make install` auto-detects the GPU vendor from the loaded kernel module (`nvidia` -> cuda, `amdgpu` -> rocm; CPU-only and WSL2 fall back to cuda), overridable with `PROFILE=cuda|rocm make install`; `BACKEND=skrl-torch|skrl-jax|rslrl` selects the training backend extra (default `skrl-torch`); `make install-dev` bootstraps the full dev environment (rocm hosts get an explicit extras list since `--all-extras` cannot combine both profiles)
- `motrix_rl.system_metrics` GPU samplers now talk to AMD SMI on ROCm hosts and NVML on NVIDIA hosts, so the FastSAC console panel reports VRAM/utilization on both vendors; unit tests added for the AMD path
- CI (`tests.yml`) installs through `make install-dev` instead of raw `uv sync`
- Docs updated for the dual-GPU flow across installation guide, env/task pages and tutorials (en + zh_CN); README hardware requirements now state "NVIDIA (CUDA) or AMD (ROCm)"
- Architecture diagram refreshed: new GPU BACKENDS row with NVIDIA / AMD logos, slogan banners moved to the top, "One CLI" bar to the bottom; README embeds it at full column width (en + zh_CN alt text)
- `microduck-walk-flat` fastsac config: `batch_size: 2048` and strict `utd_mode`

## Notes

- `make install` on hosts with neither driver loaded falls back to the cuda profile (CPU torch wheels from the cu128 index)
- Recommend squash merge
