### PR TITLE
test: share numba kernel cache across manager tests instead of per-test recompile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,6 +198,16 @@ tensorboard --logdir runs/{env-name}
 python -m pytest
 ```
 
+### 提交前检查
+
+push / 提交 PR 前，先在本地跑一次 pre-commit 钩子（ruff check、ruff format 等），确保 CI 不因 lint 失败空转：
+
+```bash
+prek run --all-files
+```
+
+若 hook 自动修改了文件，将修改并入提交后再 push。
+
 ## 架构要点
 
 - **Backend 无关 core**：`motrix_env_core` 不 import 任何 simulator；前端只通过 `motrix_env_core.sim.registry` 解析 backend。

--- a/motrix_env_core/tests/test_numba_manager.py
+++ b/motrix_env_core/tests/test_numba_manager.py
@@ -283,7 +283,18 @@ def _compile_manager(env: ManagerEnv):
     return NumbaKernelCompiler(env).build()
 
 
+# Share a single on-disk cache directory across the whole test file (hermetic,
+# never touches the user cache), but do not clear the in-process kernel caches:
+# each distinct plan is compiled once instead of per-test full recompilation
+# caused by cache-clearing autouse fixtures (issue #32).
 @pytest.fixture(autouse=True)
+def _shared_numba_cache_dir(tmp_path_factory, monkeypatch):
+    monkeypatch.setenv("NUMBA_CACHE_DIR", str(tmp_path_factory.mktemp("numba-cache")))
+
+
+# Referenced explicitly only by tests that verify cache isolation behavior:
+# additionally clear in-process caches and use a separate empty disk cache.
+@pytest.fixture
 def _isolated_numba_cache(tmp_path, monkeypatch):
     monkeypatch.setenv("NUMBA_CACHE_DIR", str(tmp_path / "numba-cache"))
     compiler_module._KERNEL_CACHE.clear()
@@ -432,7 +443,7 @@ def test_episode_reset_reuses_transition_kernel_inputs(monkeypatch: pytest.Monke
     assert read_count == 1
 
 
-def test_reset_descriptor_is_part_of_numba_kernel_cache_key() -> None:
+def test_reset_descriptor_is_part_of_numba_kernel_cache_key(_isolated_numba_cache) -> None:
     first = ManagerEnv(
         _ManagerEnvCfg(sim_reset=_DescriptorManagerResetCfg(term=_DescriptorResetTermCfg(tag="first"))),
         num_envs=1,
@@ -738,7 +749,9 @@ def test_post_reset_observation_does_not_run_command_evaluation() -> None:
     np.testing.assert_allclose(state.obs.policy[:, 2], [0.5, 1.0, 1.5])
 
 
-def test_materialize_source_is_safe_for_concurrent_same_plan_writers(tmp_path, monkeypatch) -> None:
+def test_materialize_source_is_safe_for_concurrent_same_plan_writers(
+    _isolated_numba_cache, tmp_path, monkeypatch
+) -> None:
     monkeypatch.setenv("NUMBA_CACHE_DIR", str(tmp_path))
     source = "generated = True\\n"
 
@@ -753,7 +766,7 @@ def test_materialize_source_is_safe_for_concurrent_same_plan_writers(tmp_path, m
     assert not list((tmp_path / "generated").glob("*.tmp"))
 
 
-def test_build_rematerializes_source_after_cache_invalidation(monkeypatch, tmp_path) -> None:
+def test_build_rematerializes_source_after_cache_invalidation(_isolated_numba_cache, monkeypatch, tmp_path) -> None:
     monkeypatch.setenv("NUMBA_CACHE_DIR", str(tmp_path))
     compiler_module._KERNEL_CACHE.clear()
     env = _ManagerEnv(num_envs=1)
@@ -774,7 +787,9 @@ def test_build_rematerializes_source_after_cache_invalidation(monkeypatch, tmp_p
     compiler_module._KERNEL_CACHE.pop(compiled.layout.plan_key, None)
 
 
-def test_specialization_cache_failure_rebuilds_callable_dispatchers_before_retry(monkeypatch) -> None:
+def test_specialization_cache_failure_rebuilds_callable_dispatchers_before_retry(
+    _isolated_numba_cache, monkeypatch
+) -> None:
     env = _ManagerEnv(num_envs=1)
     invalidated = []
     compile_attempts = []

--- a/motrix_env_core/tests/test_numba_manager.py
+++ b/motrix_env_core/tests/test_numba_manager.py
@@ -283,22 +283,33 @@ def _compile_manager(env: ManagerEnv):
     return NumbaKernelCompiler(env).build()
 
 
-# Share a single on-disk cache directory across the whole test file (hermetic,
+# Share a single on-disk cache directory across the whole test module (hermetic,
 # never touches the user cache), but do not clear the in-process kernel caches:
 # each distinct plan is compiled once instead of per-test full recompilation
 # caused by cache-clearing autouse fixtures (issue #32).
-@pytest.fixture(autouse=True)
-def _shared_numba_cache_dir(tmp_path_factory, monkeypatch):
+@pytest.fixture(autouse=True, scope="module")
+def _shared_numba_cache_dir(tmp_path_factory):
+    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setenv("NUMBA_CACHE_DIR", str(tmp_path_factory.mktemp("numba-cache")))
+    yield
+    monkeypatch.undo()
 
 
 # Referenced explicitly only by tests that verify cache isolation behavior:
-# additionally clear in-process caches and use a separate empty disk cache.
+# clear in-process caches and use a separate empty disk cache, restoring the
+# shared caches afterwards so later tests are not order-dependent.
 @pytest.fixture
 def _isolated_numba_cache(tmp_path, monkeypatch):
     monkeypatch.setenv("NUMBA_CACHE_DIR", str(tmp_path / "numba-cache"))
+    saved_kernel_cache = dict(compiler_module._KERNEL_CACHE)
+    saved_term_cache = dict(compiler_module._TERM_CACHE)
     compiler_module._KERNEL_CACHE.clear()
     compiler_module._TERM_CACHE.clear()
+    yield
+    compiler_module._KERNEL_CACHE.clear()
+    compiler_module._KERNEL_CACHE.update(saved_kernel_cache)
+    compiler_module._TERM_CACHE.clear()
+    compiler_module._TERM_CACHE.update(saved_term_cache)
 
 
 _GROUPS = _manager_groups()


### PR DESCRIPTION
## 问题

`motrix_env_core/tests/test_numba_manager.py` 的 `autouse` fixture `_isolated_numba_cache` 在**每个测试前**清空进程内 `_KERNEL_CACHE` / `_TERM_CACHE`，并把 `NUMBA_CACHE_DIR` 指向每个测试独立的空 tmp 目录。框架自带的同 plan 去重被完全绕过，28 个测试每个都全额重编译 Numba kernel（每个 ~1.2s，总计 ~26–31s）。

## 修改

把原 autouse fixture 拆成两层：

- **`_shared_numba_cache_dir`（autouse）**：为整个测试文件设置一个共享的 hermetic 磁盘缓存目录（`tmp_path_factory`，不落用户缓存），但**不清空进程内缓存**——同一 plan 全文件只编译一次；
- **`_isolated_numba_cache`（普通 fixture）**：保留原有的冷缓存隔离语义，仅由真正验证缓存隔离行为的测试显式引用：
  - `test_materialize_source_is_safe_for_concurrent_same_plan_writers`
  - `test_build_rematerializes_source_after_cache_invalidation`
  - `test_specialization_cache_failure_rebuilds_callable_dispatchers_before_retry`
  - `test_reset_descriptor_is_part_of_numba_kernel_cache_key`

语义上也更准确：绝大多数测试验证的是 env 行为契约，不需要冷缓存隔离。

## 效果

| | 修复前 | 修复后 |
|---|---|---|
| `test_numba_manager.py` | 28 passed in ~26–31s | 28 passed in **~11.5s** |
| `motrix_env_core/tests` 全量 | — | 127 passed，无回归 |

测试数量与覆盖不变。

Fixes #32
